### PR TITLE
Corrected issue when nodeSize is 1 and added feature to return whether a checkpoint has been done or not.

### DIFF
--- a/include/fti.h
+++ b/include/fti.h
@@ -39,6 +39,10 @@
 #define FTI_SCES    0
 /** Token returned if a FTI function fails.                                */
 #define FTI_NSCS    -1
+/** Token returned if a checkpoint has actually been performed             */
+#define FTI_CKPT_DONE       1
+/** Token returned if a checkpoint has not been performed                  */
+#define FTI_CKPT_IGNORED    0
 
 /** Verbosity level to print only errors.                                  */
 #define FTI_EROR    4
@@ -300,6 +304,7 @@ int FTI_BitFlip(int datasetID);
 int FTI_Checkpoint(int id, int level);
 int FTI_Recover();
 int FTI_Snapshot();
+int FTI_Snapshot_extended(int * res);
 int FTI_Finalize();
 
 #ifdef __cplusplus

--- a/src/api.c
+++ b/src/api.c
@@ -424,6 +424,12 @@ int FTI_Recover() {
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_Snapshot() {
+    int dummy;
+    return FTI_Snapshot(&dummy);
+}
+
+int FTI_Snapshot_extended(int * res) {
+    *res = FTI_CKPT_IGNORED;
     int i, level = -1;
     if (FTI_Exec.reco)
     { // If this is a recovery load icheckpoint data
@@ -437,7 +443,10 @@ int FTI_Snapshot() {
             exit(1);
         }
     } else { // If it is a checkpoint test
+        char str[FTI_BUFS];
         FTI_UpdateIterTime();
+        //sprintf(str, "ckptNext(%d) == ckptIcnt(%d) && ckptCnt (%d) mod ckptIntv (%d) != 0\n", FTI_Exec.ckptNext, FTI_Exec.ckptIcnt, FTI_Exec.ckptCnt, FTI_Ckpt[1].ckptIntv);
+        FTI_Print(str, FTI_DBUG);
         if (FTI_Exec.ckptNext == FTI_Exec.ckptIcnt)
         { // If it is time to check for possible ckpt. (every minute)
             FTI_Print("Checking if it is time to checkpoint.", FTI_DBUG);
@@ -456,6 +465,7 @@ int FTI_Snapshot() {
             FTI_Exec.ckptLast = FTI_Exec.ckptNext;
             FTI_Exec.ckptNext = FTI_Exec.ckptNext + FTI_Exec.ckptIntv;
             FTI_Exec.iterTime = MPI_Wtime(); // Reset iteration duration timer
+            *res = FTI_CKPT_DONE;
         }
     }
     return FTI_SCES;

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -197,7 +197,7 @@ int FTI_PostCkpt(int group, int fo, int pr) {
     t2 = MPI_Wtime();
     FTI_GroupClean(FTI_Exec.ckptLvel, group, pr);
     MPI_Barrier(FTI_COMM_WORLD);
-    nodeFlag = (((!FTI_Topo.amIaHead) && (FTI_Topo.nodeRank == 1)) || (FTI_Topo.amIaHead))? 1 : 0;
+    nodeFlag = (((!FTI_Topo.amIaHead) && (FTI_Topo.nodeRank == 0)) || (FTI_Topo.amIaHead))? 1 : 0;
     if (nodeFlag)
     {
         level = (FTI_Exec.ckptLvel != 4) ? FTI_Exec.ckptLvel : 1;

--- a/src/tools.c
+++ b/src/tools.c
@@ -178,7 +178,7 @@ int FTI_RmDir(char path[FTI_BUFS], int flag)
 int FTI_Clean(int level, int group, int rank) {
     char buf[FTI_BUFS];
     int nodeFlag, globalFlag = !FTI_Topo.splitRank;
-    nodeFlag = (((!FTI_Topo.amIaHead) && (FTI_Topo.nodeRank == 1)) || (FTI_Topo.amIaHead))? 1 : 0;
+    nodeFlag = (((!FTI_Topo.amIaHead) && (FTI_Topo.nodeRank == 0)) || (FTI_Topo.amIaHead))? 1 : 0;
     if (level == 0)
     {
         FTI_RmDir(FTI_Conf.mTmpDir, globalFlag);


### PR DESCRIPTION
- When nodeSize is 1, nodeRank is always 0. Therefore, if there are no heads,
  nodeFlag becomes always 0 and so, the temporal directory where the checkpoints
  are being stored is not renamed and then, in the restart, FTI is not able to
  find the checkpoints, although they exist, because they are not in the expected
  directory.
  Changing the condition "nodeRank==1" to "nodeRank==0" when setting nodeFlag,
  this issue is solved and the checkpoint/restart works as expected.

- Added feature to inform the user if a checkpoint has been performed or not
 when using FTI_Snapshot. Now, it is possible to pass an integer as a
 parameter to FTI_Snapshot and it will be 1 if the checkpoint has been
 performed and 0 otherwise.

