### PR TITLE
Bugfix fullwrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,10 @@ append_property(TARGET fti.static fti.shared
 set_property(TARGET fti.static fti.shared
 	PROPERTY OUTPUT_NAME fti)
 
-target_link_libraries(fti.static ${MPI_C_LIBRARIES})
-target_link_libraries(fti.shared ${MPI_C_LIBRARIES})
+find_library(LIBM m DOC "The math library")
+
+target_link_libraries(fti.static ${MPI_C_LIBRARIES} "${LIBM}") 
+target_link_libraries(fti.shared ${MPI_C_LIBRARIES} "${LIBM}")
 
 set(FTI_TARGETS fti.static fti.shared)
 install(TARGETS fti.static fti.shared DESTINATION lib)

--- a/include/fti.h
+++ b/include/fti.h
@@ -100,7 +100,7 @@ typedef struct FTIT_type {              /** FTI type declarator.           */
 typedef struct FTIT_dataset {           /** Dataset metadata.              */
     int             id;                 /** ID to search/update dataset.   */
     void            *ptr;               /** Pointer to the dataset.        */
-    int             count;              /** Number of elements in dataset. */
+    long            count;              /** Number of elements in dataset. */
     FTIT_type       type;               /** Data type for the dataset.     */
     int             eleSize;            /** Element size for the dataset.  */
     long            size;               /** Total size of the dataset.     */


### PR DESCRIPTION
`fwrite` sometimes only write part of the provided data. E.g when it is more than 2GB. This workarounds this by calling it multiple times in a loop.