### PR TITLE
Contains an initial port to the CPPR APIs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,26 @@ if(POLICY CMP0054)
 endif()
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-	project(FTI C Fortran)
+       project(FTI C Fortran)
 endif()
 
 option(ENABLE_FORTRAN "Enables the generation of the Fortran wrapper for FTI" ON)
 option(ENABLE_EXAMPLES "Enables the generation of examples" ON)
+option(ENABLE_CPPR "Enables the use of CPPR as the underlying file movement service" OFF)
+set(CPPR_PATH "" CACHE PATH "user specified path to cppr")
+if(ENABLE_CPPR)
+     set(CPPR_INCLUDE_DIR "${CPPR_PATH}/include")
+     set(CPPR_LIBRARY "${CPPR_PATH}/lib/libcppr.so")
+     find_path(CPPR_INCLUDE_DIR cppr.h)
+     find_library(CPPR_LIBRARY libcppr)
+endif()
+
+
+if(CPPR_INCLUDE_DIR AND CPPR_LIBRARY)
+     set(CPPR_FOUND TRUE)
+     add_definitions(-DHAVE_LIBCPPR=1)
+
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeScripts")
 include(AppendProperty)
@@ -21,7 +36,7 @@ add_subdirectory(deps)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_SOURCE_DIR}/include"
-	${MPI_Fortran_INCLUDE_PATH} ${MPI_C_INCLUDE_PATH})
+	${MPI_Fortran_INCLUDE_PATH} ${MPI_C_INCLUDE_PATH} ${CPPR_INCLUDE_DIR})
 
 set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
@@ -44,8 +59,15 @@ append_property(TARGET fti.static fti.shared
 set_property(TARGET fti.static fti.shared
 	PROPERTY OUTPUT_NAME fti)
 
-target_link_libraries(fti.static ${MPI_C_LIBRARIES})
-target_link_libraries(fti.shared ${MPI_C_LIBRARIES})
+
+if(CPPR_FOUND)
+     target_link_libraries(fti.static ${MPI_C_LIBRARIES} ${CPPR_LIBRARY})
+     target_link_libraries(fti.shared ${MPI_C_LIBRARIES} ${CPPR_LIBRARY})
+else()
+     target_link_libraries(fti.static ${MPI_C_LIBRARIES})
+     target_link_libraries(fti.shared ${MPI_C_LIBRARIES})
+endif()
+
 
 set(FTI_TARGETS fti.static fti.shared)
 install(TARGETS fti.static fti.shared DESTINATION lib)

--- a/src/api.c
+++ b/src/api.c
@@ -7,6 +7,9 @@
 
 #include "interface.h"
 
+#ifdef HAVE_LIBCPPR
+#include "cppr.h"
+#endif
 /** General configuration information used by FTI.                         */
 static FTIT_configuration FTI_Conf;
 
@@ -102,6 +105,19 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
     FTI_Try(FTI_InitBasicTypes(FTI_Data), "create the basic data types.");
     if (FTI_Topo.myRank == 0)
         FTI_Try(FTI_UpdateConf(&FTI_Conf, &FTI_Exec, 1), "update configuration file.");
+#ifdef HAVE_LIBCPPR
+    /* try to init libcppr */
+    int cppr_ret;
+    cppr_ret = cppr_status();
+
+
+    if(cppr_ret != CPPR_SUCCESS){
+            FTI_Print("cppr failed initializing", FTI_WARN);
+            FTI_Abort();
+    }
+    FTI_Print("CPPR init'd successfully", FTI_INFO);
+
+#endif
     if (FTI_Topo.amIaHead) { // If I am a FTI dedicated process
         if (FTI_Exec.reco) {
             res = FTI_Try(FTI_RecoverFiles(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt), "recover the checkpoint files.");


### PR DESCRIPTION
This is a configure time feature, which is disabled by default.

To enable this code, add the following to the cmake command:
-D'ENABLE_CPPR:BOOL=ON' -D'CPPR_PATH:PATH=[path to cppr]'

This PR isn't ready to be merged, and is just a working example for reference
     only.

This code shows the use of the synchronous CPPR API.  This code is executed in
     the following situations:
In FTIs asynchronous mode,
     L4 checkpoints are copied using cppr_mv_wait() rather than with fread() and
     fwrite().  Also, in FTI_Flush(), cppr_mv_wait() is used to copy the final
     checkpoint (regardless of level) to global storage. Finally, in a restart,
     cppr_mv_wait() is used to copy files from the global storage to local
     storage.
In FTIs synchronous mode,
     the asynchronous CPPR API would be a further optimization to this code
     because it could offload the copy to the CPPR process.  This optimization
     would go as follows: modify the synchronous code path for L4 checkpoints
     in FTI to become a "write to local storage" and then a call to cppr_mv()
     to kick off the copy of the local file to global storage asynchronously.
     Then upon the next checkpoint,  the handle returned by CPPR would be
     waited on to ensure the copy completed successfully.  This is in contrast
     with the way L4 checkpoints currently work in FTI in synchronous mode
     where the write is done directly to the global storage and there is no
     transfer step.

The CPPR team would be happy to help get this code to a state where it is
     production quality and ready to be merged.