### PR TITLE
ConfigFix

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -105,6 +105,7 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
     if (FTI_Topo.myRank == 0) {
         FTI_Try(FTI_UpdateConf(&FTI_Conf, &FTI_Exec, FTI_Exec.reco), "update configuration file.");
     }
+    MPI_Barrier(FTI_Exec.globalComm); //wait for myRank == 0 process to save config file
     if (FTI_Topo.amIaHead) { // If I am a FTI dedicated process
         if (FTI_Exec.reco) {
             res = FTI_Try(FTI_RecoverFiles(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt), "recover the checkpoint files.");


### PR DESCRIPTION
Sometimes I have got on Travis bug when verbosity wasn't set to 1,2 or 3 (config file was corrupted). I spent some time on it and I found that myRank == 0 process can call UpdateConf (where it opens conf file) and in the same time some app process can call it after post-checkpoint (api.c, FTI_Checkpoint(), line 402). That is why we need to set this barrier in FTI_Init.