### PR TITLE
Solves issue after recovering from L4 data init not from local FS

### DIFF
--- a/src/recover.c
+++ b/src/recover.c
@@ -185,6 +185,9 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             if (tres == FTI_SCES) {
                 sprintf(str, "Recovering successfully from level %d.", level);
                 FTI_Print(str, FTI_INFO);
+                if (level == 4) {
+                    FTI_Exec->ckptLvel = 1;
+                }
                 break;
             }
             else {


### PR DESCRIPTION
Details:
During L4 recovery in FTI_Init, the ckpt files are moved to the local FS
The recovery of the data during FTI_Recover, however, was still done from
the PFS. That made the transfer to local during FTI_Init meaningless.

With this commit, the ckpt data is recovered from L1 directory during
FTI_Recover.
-------------------------------------
_internal info -> local tests (./run-checks -d -c -e) successfull._