### PR TITLE
fixes slow flush to PFS in MPIIO L4 ckpt

### DIFF
--- a/examples/config.fti
+++ b/examples/config.fti
@@ -102,6 +102,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/examples/configBkp.fti
+++ b/examples/configBkp.fti
@@ -102,6 +102,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/include/fti.h
+++ b/include/fti.h
@@ -181,6 +181,7 @@ typedef struct FTIT_configuration {     /** Configuration metadata.        */
     int             saveLastCkpt;       /** TRUE to save last checkpoint.  */
     int             verbosity;          /** Verbosity level.               */
     int             blockSize;          /** Communication block size.      */
+    int             transferSize;       /** Transfer size local to PFS     */
     int             tag;                /** Tag for MPI messages in FTI.   */
     int             test;               /** TRUE if local test.            */
     int             l3WordSize;         /** RS encoding word size.         */

--- a/src/conf.c
+++ b/src/conf.c
@@ -128,7 +128,7 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FTI_Conf->verbosity = (int)iniparser_getint(ini, "Basic:verbosity", -1);
     FTI_Conf->saveLastCkpt = (int)iniparser_getint(ini, "Basic:keep_last_ckpt", 0);
     FTI_Conf->blockSize = (int)iniparser_getint(ini, "Advanced:block_size", -1) * 1024;
-    FTI_Conf->TransferSize = (int)iniparser_getint(ini, "Advanced:transfer_size", -1) * 1024 * 1024;
+    FTI_Conf->transferSize = (int)iniparser_getint(ini, "Advanced:transfer_size", -1) * 1024 * 1024;
     FTI_Conf->tag = (int)iniparser_getint(ini, "Advanced:mpi_tag", -1);
     FTI_Conf->test = (int)iniparser_getint(ini, "Advanced:local_test", -1);
     FTI_Conf->l3WordSize = FTI_WORD;

--- a/src/conf.c
+++ b/src/conf.c
@@ -128,7 +128,7 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FTI_Conf->verbosity = (int)iniparser_getint(ini, "Basic:verbosity", -1);
     FTI_Conf->saveLastCkpt = (int)iniparser_getint(ini, "Basic:keep_last_ckpt", 0);
     FTI_Conf->blockSize = (int)iniparser_getint(ini, "Advanced:block_size", -1) * 1024;
-    FTI_Conf->transferSize = (int)iniparser_getint(ini, "Advanced:transfer_size", -1) * 1024 * 1024;
+    FTI_Conf->TransferSize = (int)iniparser_getint(ini, "Advanced:transfer_size", -1) * 1024 * 1024;
     FTI_Conf->tag = (int)iniparser_getint(ini, "Advanced:mpi_tag", -1);
     FTI_Conf->test = (int)iniparser_getint(ini, "Advanced:local_test", -1);
     FTI_Conf->l3WordSize = FTI_WORD;
@@ -236,8 +236,8 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
         return FTI_NSCS;
     }
     if (FTI_Conf->transferSize > (1024 * 1024 * 64) || FTI_Conf->transferSize < (1024 * 1024 * 8)) {
-        FTI_Print("Transfer size needs to be set between 8MB and 64MB.", FTI_WARN);
-        return FTI_NSCS;
+        FTI_Print("Transfer size (default = 16MB) not set in Cofiguration file.", FTI_WARN);
+        FTI_Conf->transferSize = 16 * 1024 * 1024;
     }
     if (FTI_Conf->test != 0 && FTI_Conf->test != 1) {
         FTI_Print("Local test size needs to be set to 0 or 1.", FTI_WARN);

--- a/src/conf.c
+++ b/src/conf.c
@@ -128,6 +128,7 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FTI_Conf->verbosity = (int)iniparser_getint(ini, "Basic:verbosity", -1);
     FTI_Conf->saveLastCkpt = (int)iniparser_getint(ini, "Basic:keep_last_ckpt", 0);
     FTI_Conf->blockSize = (int)iniparser_getint(ini, "Advanced:block_size", -1) * 1024;
+    FTI_Conf->transferSize = (int)iniparser_getint(ini, "Advanced:transfer_size", -1) * 1024 * 1024;
     FTI_Conf->tag = (int)iniparser_getint(ini, "Advanced:mpi_tag", -1);
     FTI_Conf->test = (int)iniparser_getint(ini, "Advanced:local_test", -1);
     FTI_Conf->l3WordSize = FTI_WORD;
@@ -232,6 +233,10 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
     }
     if (FTI_Conf->blockSize > (2048 * 1024) || FTI_Conf->blockSize < (1 * 1024)) {
         FTI_Print("Block size needs to be set between 1 and 2048.", FTI_WARN);
+        return FTI_NSCS;
+    }
+    if (FTI_Conf->transferSize > (1024 * 1024 * 64) || FTI_Conf->transferSize < (1024 * 1024 * 8)) {
+        FTI_Print("Transfer size needs to be set between 8MB and 64MB.", FTI_WARN);
         return FTI_NSCS;
     }
     if (FTI_Conf->test != 0 && FTI_Conf->test != 1) {

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -407,9 +407,9 @@ int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
    int splitRank = (FTI_Topo->amIaHead) ? gRank - ( (FTI_Topo->splitRank+1) * FTI_Topo->nbHeads ) : FTI_Topo->splitRank;
 
    // align ps to blocksize
-   ps = (FTI_Exec->meta[member].maxFs / FTI_Conf->blockSize) * FTI_Conf->blockSize;
+   ps = (FTI_Exec->meta[member].maxFs / FTI_Conf->transferSize) * FTI_Conf->transferSize;
    if (ps < FTI_Exec->meta[member].maxFs) {
-      ps = ps + FTI_Conf->blockSize;
+      ps = ps + FTI_Conf->transferSize;
    }
 
    switch (level) {
@@ -489,12 +489,12 @@ int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 #endif
    }
 
-   char *blBuf1 = talloc(char, FTI_Conf->blockSize);
-   unsigned long bSize = FTI_Conf->blockSize;
+   char *blBuf1 = talloc(char, FTI_Conf->transferSize);
+   unsigned long bSize = FTI_Conf->transferSize;
 
    // Checkpoint files exchange
    while (pos < ps) {
-      if ((FTI_Exec->meta[member].fs - pos) < FTI_Conf->blockSize)
+      if ((FTI_Exec->meta[member].fs - pos) < FTI_Conf->transferSize)
          bSize = FTI_Exec->meta[member].fs - pos;
 
       size_t bytes = fread(blBuf1, sizeof(char), bSize, lfd);
@@ -572,7 +572,7 @@ int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 #endif
       }
 
-      pos = pos + FTI_Conf->blockSize;
+      pos = pos + FTI_Conf->transferSize;
 
    }
 

--- a/src/postreco.c
+++ b/src/postreco.c
@@ -887,9 +887,9 @@ int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
    }
 
    // number of blocks
-   nbBlocks = (FTI_Exec->meta[0].fs) / FTI_Conf->blockSize;
+   nbBlocks = (FTI_Exec->meta[0].fs) / FTI_Conf->transferSize;
    block = 0; // For the logic
-   lastBlockBytes = (FTI_Exec->meta[0].fs) % FTI_Conf->blockSize; // modulo for size of last block in bytes
+   lastBlockBytes = (FTI_Exec->meta[0].fs) % FTI_Conf->transferSize; // modulo for size of last block in bytes
 
    lfd = fopen(lfn, "wb");
    if (lfd == NULL) {
@@ -898,13 +898,13 @@ int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
       return FTI_NSCS;
    }
 
-   char *blBuf1 = talloc(char, FTI_Conf->blockSize);
+   char *blBuf1 = talloc(char, FTI_Conf->transferSize);
 
    // Checkpoint files transfer from PFS
    while (block < nbBlocks) {
 
       // read block in parallel file
-      buf = MPI_File_read_at(pfh, offset, blBuf1, FTI_Conf->blockSize, MPI_BYTE, &status);
+      buf = MPI_File_read_at(pfh, offset, blBuf1, FTI_Conf->transferSize, MPI_BYTE, &status);
       // check if successfull
       if (buf != 0) {
          errno = 0;
@@ -916,7 +916,7 @@ int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
          return FTI_NSCS;
       }
 
-      fwrite(blBuf1, sizeof(char), FTI_Conf->blockSize, lfd);
+      fwrite(blBuf1, sizeof(char), FTI_Conf->transferSize, lfd);
       if (ferror(lfd)) {
          FTI_Print("R4 cannot write to the local ckpt. file.", FTI_DBUG);
          free(blBuf1);
@@ -925,7 +925,7 @@ int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
          return  FTI_NSCS;
       }
 
-      offset += FTI_Conf->blockSize;
+      offset += FTI_Conf->transferSize;
       block++;
    }
 

--- a/test/configs/configH0I1.fti
+++ b/test/configs/configH0I1.fti
@@ -106,6 +106,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/test/configs/configH0I1Silent.fti
+++ b/test/configs/configH0I1Silent.fti
@@ -106,6 +106,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/test/configs/configH1I0.fti
+++ b/test/configs/configH1I0.fti
@@ -106,6 +106,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/test/configs/configH1I0Silent.fti
+++ b/test/configs/configH1I0Silent.fti
@@ -106,6 +106,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/test/configs/configH1I1.fti
+++ b/test/configs/configH1I1.fti
@@ -106,6 +106,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/test/configs/configH1I1Silent.fti
+++ b/test/configs/configH1I1Silent.fti
@@ -106,6 +106,10 @@ frequency = 0
 # The ckpt files are decomposed in blocks of size Block_size KB
 Block_size = 1024
 
+# The ckpt files are transfered in chunks of size Transfer_size MB 
+# from local to PFS
+Transfer_size = 16
+
 # The tag for MPI communications done within the FTI library
 Mpi_tag = 2612
 

--- a/test/local/run-checks-f90.in
+++ b/test/local/run-checks-f90.in
@@ -172,6 +172,7 @@ frequency                      = 0
 
 [advanced]
 block_size                     = 1024
+transfer_size                  = 16
 mpi_tag                        = 2612
 local_test                     = 1
 EOF

--- a/test/local/run-checks.in
+++ b/test/local/run-checks.in
@@ -172,6 +172,7 @@ frequency                      = 0
 
 [advanced]
 block_size                     = 1024
+transfer_size                  = 16
 mpi_tag                        = 2612
 local_test                     = 1
 EOF


### PR DESCRIPTION
new member in FTI_Conf introduced:
- transferSize
To set in Config file. 
Size between 8MB and 64MB.