### PR TITLE
Fti clean fix

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -102,7 +102,7 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
         if (FTI_Exec.reco) {
             FTI_Critical(FTI_RecoverFiles(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt), "recover the checkpoint files.");
         }
-        res = 0;
+        int res = 0;
         while (res != FTI_ENDW) {
             res = FTI_Listen(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt);
         }

--- a/src/api.c
+++ b/src/api.c
@@ -63,7 +63,7 @@ FTIT_type FTI_LDBE;
 /*-------------------------------------------------------------------------*/
 void FTI_Abort()
 {
-    FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, 5, 0, FTI_Topo.myRank);
+    FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, 5);
     MPI_Abort(MPI_COMM_WORLD, -1);
     MPI_Finalize();
     exit(1);
@@ -213,10 +213,7 @@ int FTI_Protect(int id, void* ptr, long count, FTIT_type type)
     else {
         if (FTI_Exec.nbVar >= FTI_BUFS) {
             FTI_Print("Too many variables registered.", FTI_EROR);
-            FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, 5, FTI_Topo.groupID, FTI_Topo.myRank);
-            MPI_Abort(MPI_COMM_WORLD, -1);
-            MPI_Finalize();
-            exit(1);
+            FTI_Abort();
         }
         FTI_Data[FTI_Exec.nbVar].id = id;
         FTI_Data[FTI_Exec.nbVar].ptr = ptr;
@@ -472,10 +469,7 @@ int FTI_Snapshot()
         res = FTI_Try(FTI_Recover(), "recover the checkpointed data.");
         if (res == FTI_NSCS) {
             FTI_Print("Impossible to load the checkpoint data.", FTI_EROR);
-            FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, 5, FTI_Topo.groupID, FTI_Topo.myRank);
-            MPI_Abort(MPI_COMM_WORLD, -1);
-            MPI_Finalize();
-            exit(1);
+            FTI_Abort();
         }
     }
     else { // If it is a checkpoint test
@@ -594,7 +588,7 @@ int FTI_Finalize()
         buff = 5; // For cleaning everything
     }
     MPI_Barrier(FTI_Exec.globalComm);
-    FTI_Try(FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, buff, FTI_Topo.groupID, FTI_Topo.myRank), "do final clean.");
+    FTI_Try(FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, buff), "do final clean.");
     FTI_Print("FTI has been finalized.", FTI_INFO);
     return FTI_SCES;
 }

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -146,7 +146,7 @@ int FTI_GroupClean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
         if (FTI_Topo->amIaHead) {
             rank = FTI_Topo->body[i];
         }
-        FTI_Clean(FTI_Conf, FTI_Topo, FTI_Ckpt, level, i + group, rank);
+        FTI_Clean(FTI_Conf, FTI_Topo, FTI_Ckpt, level);
     }
     return FTI_SCES;
 }

--- a/src/interface.h
+++ b/src/interface.h
@@ -158,7 +158,9 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_Checksum(char* fileName, char* checksum);
 int FTI_VerifyChecksum(char* fileName, char* checksumToCmp);
 int FTI_Try(int result, char* message);
-void FTI_Critical(int result, char* message);
+void FTI_InitCritical(int result, char* message, FTIT_execution* FTI_Exec);
+void FTI_Critical(int result, char* message, FTIT_configuration* FTI_Conf,
+                    FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo);
 int FTI_InitBasicTypes(FTIT_dataset* FTI_Data);
 int FTI_RmDir(char path[FTI_BUFS], int flag);
 int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,

--- a/src/interface.h
+++ b/src/interface.h
@@ -161,7 +161,7 @@ int FTI_Try(int result, char* message);
 int FTI_InitBasicTypes(FTIT_dataset* FTI_Data);
 int FTI_RmDir(char path[FTI_BUFS], int flag);
 int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
-              FTIT_checkpoint* FTI_Ckpt, int level, int group, int rank);
+              FTIT_checkpoint* FTI_Ckpt, int level);
 
 int FTI_SaveTopo(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo, char *nameList);
 int FTI_ReorderNodes(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,

--- a/src/interface.h
+++ b/src/interface.h
@@ -158,6 +158,7 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_Checksum(char* fileName, char* checksum);
 int FTI_VerifyChecksum(char* fileName, char* checksumToCmp);
 int FTI_Try(int result, char* message);
+void FTI_Critical(int result, char* message);
 int FTI_InitBasicTypes(FTIT_dataset* FTI_Data);
 int FTI_RmDir(char path[FTI_BUFS], int flag);
 int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,

--- a/src/recover.c
+++ b/src/recover.c
@@ -161,7 +161,7 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                FTI_Exec->ckptLvel = level;
                switch (FTI_Exec->ckptLvel) {
                   case 4:
-                     FTI_Clean(FTI_Conf, FTI_Topo, FTI_Ckpt, 1, FTI_Topo->groupID, FTI_Topo->myRank);
+                     FTI_Clean(FTI_Conf, FTI_Topo, FTI_Ckpt, 1);
                      MPI_Barrier(FTI_COMM_WORLD);
                      switch(FTI_Conf->ioMode) {
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -138,6 +138,31 @@ int FTI_Try(int result, char* message)
 
 /*-------------------------------------------------------------------------*/
 /**
+    @brief      It receives the return code of a critical function.
+    @param      result          Result to check.
+    @param      message         Message to print.
+
+    This function checks the result from a critical function and if result is
+    not success terminates all processes, otherwise print the debug message.
+
+ **/
+/*-------------------------------------------------------------------------*/
+void FTI_Critical(int result, char* message)
+{
+    char str[FTI_BUFS];
+    if (result == FTI_SCES || result == FTI_DONE) {
+        sprintf(str, "FTI succeeded to %s", message);
+        FTI_Print(str, FTI_DBUG);
+    }
+    else {
+        sprintf(str, "FTI failed to %s", message);
+        FTI_Print(str, FTI_EROR);
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    }
+}
+
+/*-------------------------------------------------------------------------*/
+/**
     @brief      It creates the basic datatypes and the dataset array.
     @param      FTI_Data        Dataset array.
     @return     integer         FTI_SCES if successful.

--- a/src/tools.c
+++ b/src/tools.c
@@ -138,6 +138,36 @@ int FTI_Try(int result, char* message)
 
 /*-------------------------------------------------------------------------*/
 /**
+    @brief      It receives the return code of a init critical function.
+    @param      result          Result to check.
+    @param      message         Message to print.
+
+    This function checks the result from a critical function which is in FTI_Init
+    where heads are not in FTI_Listen yet and if result is not success terminates
+    all processes, otherwise print the debug message.
+
+ **/
+/*-------------------------------------------------------------------------*/
+void FTI_InitCritical(int result, char* message, FTIT_execution* FTI_Exec)
+{
+    char str[FTI_BUFS];
+    if (result == FTI_SCES) {
+        sprintf(str, "FTI succeeded to %s", message);
+        FTI_Print(str, FTI_DBUG);
+    }
+    else {
+        sprintf(str, "FTI failed to %s", message);
+        int allResults;
+        MPI_Allreduce(&result, &allResults, 1, MPI_INT, MPI_SUM, FTI_Exec->globalComm);
+        if (allResults != FTI_SCES) {
+            FTI_Print("Exiting with status 1.", FTI_DBUG);
+            exit(1);
+        }
+    }
+}
+
+/*-------------------------------------------------------------------------*/
+/**
     @brief      It receives the return code of a critical function.
     @param      result          Result to check.
     @param      message         Message to print.
@@ -147,7 +177,8 @@ int FTI_Try(int result, char* message)
 
  **/
 /*-------------------------------------------------------------------------*/
-void FTI_Critical(int result, char* message)
+void FTI_Critical(int result, char* message, FTIT_configuration* FTI_Conf,
+                    FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo)
 {
     char str[FTI_BUFS];
     if (result == FTI_SCES || result == FTI_DONE) {
@@ -156,8 +187,16 @@ void FTI_Critical(int result, char* message)
     }
     else {
         sprintf(str, "FTI failed to %s", message);
-        FTI_Print(str, FTI_EROR);
-        MPI_Abort(MPI_COMM_WORLD, -1);
+        int allResults, endWork = FTI_ENDW;
+        MPI_Allreduce(&result, &allResults, 1, MPI_INT, MPI_SUM, FTI_COMM_WORLD);
+        if (allResults != FTI_SCES) {
+            if (FTI_Topo->nbHeads == 1) {
+                FTI_Print("Sending FTI_ENDW to the head process", FTI_DBUG);
+                MPI_Send(&endWork, 1, MPI_INT, FTI_Topo->headRank, FTI_Conf->tag, FTI_Exec->globalComm);
+            }
+            FTI_Print("Exiting with status 1.", FTI_DBUG);
+            exit(1);
+        }
     }
 }
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -228,8 +228,6 @@ int FTI_RmDir(char path[FTI_BUFS], int flag)
 /**
     @brief      It erases the previous checkpoints and their metadata.
     @param      level           Level of cleaning.
-    @param      group           Group ID of the cleaning target process.
-    @param      rank            Rank of the cleaning target process.
     @return     integer         FTI_SCES if successful.
 
     This function erases previous checkpoint depending on the level of the
@@ -239,7 +237,7 @@ int FTI_RmDir(char path[FTI_BUFS], int flag)
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
-              FTIT_checkpoint* FTI_Ckpt, int level, int group, int rank)
+              FTIT_checkpoint* FTI_Ckpt, int level)
 {
     char buf[FTI_BUFS];
     int nodeFlag, globalFlag = !FTI_Topo->splitRank;


### PR DESCRIPTION
1. Changed  FTI_Abort function: removed FTI_Clean, because we don't know which process will call MPI_Abort first, the clean won't be executed anyway. After MPI_Abort no instructions are executed so no point to call it.
2. FTI_Clean had unused parameters: group and rank.
3. Added FTI_Critical similar to FTI_Try, but if fail it calls FTI_Abort. (cleaner code)