### PR TITLE
Clean code for L4 IO and changed metadata

### DIFF
--- a/include/fti.h
+++ b/include/fti.h
@@ -62,6 +62,9 @@
 /** Token for IO mode MPI.                                                 */
 #define FTI_IO_MPI 1002
 
+/** Hashed string length.                                                */
+#define MD5_DIGEST_LENGTH 17
+
 #ifdef ENABLE_SIONLIB // --> If SIONlib is installed
     /** Token for IO mode SIONlib.                                         */
     #define FTI_IO_SIONLIB 1003
@@ -122,6 +125,8 @@ typedef struct FTIT_dataset {
     FTIT_type       type;               /**< Data type for the dataset.     */
     int             eleSize;            /**< Element size for the dataset.  */
     long            size;               /**< Total size of the dataset.     */
+    /** MD5 Checksum                    */
+    char            checksum[MD5_DIGEST_LENGTH];
 } FTIT_dataset;
 
 /** @typedef    FTIT_metadata
@@ -130,9 +135,11 @@ typedef struct FTIT_dataset {
  *  This type stores all the metadata necessary for the restart.
  */
 typedef struct FTIT_metadata {
-    long            maxFs;              /**< Maximum file size.             */
-    long            fs;                 /**< File size.                     */
-    char            ckptFile[FTI_BUFS]; /**< Ckpt file name.                */
+    int*             exists;             /**< True if metadata exists        */
+    long*            maxFs;              /**< Maximum file size.             */
+    long*            fs;                 /**< File size.                     */
+    long*            pfs;                /**< Partner file size.             */
+    char*            ckptFile;           /**< Ckpt file name. [FTI_BUFS]     */
 } FTIT_metadata;
 
 /** @typedef    FTIT_execution
@@ -142,17 +149,12 @@ typedef struct FTIT_metadata {
  */
 typedef struct FTIT_execution {
     char            id[FTI_BUFS];       /**< Execution ID.                  */
-    char            ckptFile[FTI_BUFS]; /**< Checkpoint file name.          */
-    char            fn[FTI_BUFS];       /**< Temp file name full path.      */
     int             ckpt;               /**< Checkpoint flag.               */
     int             reco;               /**< Recovery flag.                 */
     int             ckptLvel;           /**< Checkpoint level.              */
     int             ckptIntv;           /**< Ckpt. interval in minutes.     */
     int             lastCkptLvel;       /**< Last checkpoint level.         */
     int             wasLastOffline;     /**< TRUE if last ckpt. offline.    */
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-    int             sid;                /**< SIONlib filehandle             */
-#endif
     double          iterTime;           /**< Current wall time.             */
     double          lastIterTime;       /**< Time spent in the last iter.   */
     double          meanIterTime;       /**< Mean iteration time.           */
@@ -168,8 +170,7 @@ typedef struct FTIT_execution {
     long            ckptSize;           /**< Checkpoint size.               */
     unsigned int    nbVar;              /**< Number of protected variables. */
     unsigned int    nbType;             /**< Number of data types.          */
-    FTIT_metadata   *meta;              /**< Metadata for restart           */
-    MPI_File        pfh;                /**< MPI-IO file handle             */
+    FTIT_metadata   meta[5];            /**< Metadata for each ckpt level   */
     MPI_Comm        globalComm;         /**< Global communicator.           */
     MPI_Comm        groupComm;          /**< Group communicator.            */
 } FTIT_execution;

--- a/src/api.c
+++ b/src/api.c
@@ -71,6 +71,48 @@ void FTI_Abort()
 
 /*-------------------------------------------------------------------------*/
 /**
+    @brief      It prints the metadata.
+    @param      FTI_Exec        Execution metadata.
+    @param      FTI_Topo        Topology metadata.
+
+    This function prints the metadata for each process.
+
+ **/
+/*-------------------------------------------------------------------------*/
+void FTI_PrintMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo)
+{
+    int i, j, k;
+    char str[FTI_BUFS];
+    for (i = 0; i < FTI_Topo->nbProc; i++) {
+        if (FTI_Topo->myRank == i) {
+            if (FTI_Topo->amIaHead) {
+                sprintf(str, "I am a head. Node: %d, Group: %d", FTI_Topo->nodeID, FTI_Topo->groupID);
+                FTI_Print(str, FTI_WARN);
+                for (j = 1; j < FTI_Topo->nodeSize; j++) {
+                    for (k = 0; k < 5; k++) {
+                        sprintf(str, "Approcs %d: Level: %d; Exists: %d; fs: %ld; maxFs: %ld, pfs: %ld; ckptFile: %s",
+                                j, k, FTI_Exec->meta[k].exists[j], FTI_Exec->meta[k].fs[j], FTI_Exec->meta[k].maxFs[j],
+                                FTI_Exec->meta[k].pfs[j], &FTI_Exec->meta[k].ckptFile[j * FTI_BUFS]);
+                        FTI_Print(str, FTI_WARN);
+                    }
+                }
+            }
+            else {
+                for (k = 0; k < 5; k++) {
+                    sprintf(str, "Level: %d; Exists: %d; fs: %ld; maxFs: %ld, pfs: %ld; ckptFile: %s",
+                            k, FTI_Exec->meta[k].exists[0], FTI_Exec->meta[k].fs[0], FTI_Exec->meta[k].maxFs[0],
+                            FTI_Exec->meta[k].pfs[0], FTI_Exec->meta[k].ckptFile);
+                    FTI_Print(str, FTI_WARN);
+                }
+            }
+        }
+        MPI_Barrier(FTI_COMM_WORLD);
+    }
+}
+
+
+/*-------------------------------------------------------------------------*/
+/**
     @brief      Initializes FTI.
     @param      configFile      FTI configuration file.
     @param      globalComm      Main MPI communicator of the application.
@@ -106,8 +148,12 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
         FTI_Try(FTI_UpdateConf(&FTI_Conf, &FTI_Exec, FTI_Exec.reco), "update configuration file.");
     }
     MPI_Barrier(FTI_Exec.globalComm); //wait for myRank == 0 process to save config file
+    FTI_MallocMeta(&FTI_Exec, &FTI_Topo);
+    res = FTI_Try(FTI_LoadMeta(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt), "load metadata");
+    if (res == FTI_NSCS) {
+        FTI_Abort();
+    }
     if (FTI_Topo.amIaHead) { // If I am a FTI dedicated process
-        FTI_Exec.meta = talloc(FTIT_metadata,FTI_Topo.nbApprocs);
         if (FTI_Exec.reco) {
             res = FTI_Try(FTI_RecoverFiles(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt), "recover the checkpoint files.");
             if (res != FTI_SCES) {
@@ -122,7 +168,6 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
         FTI_Finalize();
     }
     else { // If I am an application process
-        FTI_Exec.meta = talloc(FTIT_metadata,1);
         if (FTI_Exec.reco) {
             res = FTI_Try(FTI_RecoverFiles(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt), "recover the checkpoint files.");
             if (res != FTI_SCES) {
@@ -426,7 +471,7 @@ int FTI_Recover()
     char fn[FTI_BUFS], str[FTI_BUFS];
     FILE* fd;
     int i;
-    sprintf(fn, "%s/%s", FTI_Ckpt[FTI_Exec.ckptLvel].dir, FTI_Exec.ckptFile);
+    sprintf(fn, "%s/%s", FTI_Ckpt[FTI_Exec.ckptLvel].dir, FTI_Exec.meta[FTI_Exec.ckptLvel].ckptFile);
     sprintf(str, "Trying to load FTI checkpoint file (%s)...", fn);
     FTI_Print(str, FTI_DBUG);
 
@@ -525,6 +570,7 @@ int FTI_Finalize()
     int isCkpt;
 
     if (FTI_Topo.amIaHead) {
+        FTI_FreeMeta(&FTI_Exec);
         MPI_Barrier(FTI_Exec.globalComm);
         MPI_Finalize();
         exit(0);
@@ -554,9 +600,7 @@ int FTI_Finalize()
     // If we need to keep the last checkpoint
     if (FTI_Conf.saveLastCkpt && FTI_Exec.ckptID > 0) {
         if (FTI_Exec.lastCkptLvel != 4) {
-            FTI_Try(FTI_FlushInit(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt, FTI_Exec.lastCkptLvel), "Initialize flush to the PFS.");
-            FTI_Try(FTI_Flush(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt, FTI_Topo.groupID, FTI_Exec.lastCkptLvel), "save the last ckpt. in the PFS.");
-            FTI_Try(FTI_FlushFinalize(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt, FTI_Exec.lastCkptLvel), "Finalize flush to the PFS.");
+            FTI_Try(FTI_Flush(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt, FTI_Exec.lastCkptLvel), "save the last ckpt. in the PFS.");
             MPI_Barrier(FTI_COMM_WORLD);
             if (FTI_Topo.splitRank == 0) {
                 if (access(FTI_Ckpt[4].dir, 0) == 0) {
@@ -565,14 +609,8 @@ int FTI_Finalize()
                 if (access(FTI_Ckpt[4].metaDir, 0) == 0) {
                     FTI_RmDir(FTI_Ckpt[4].metaDir, 1);
                 }
-                if ( FTI_Conf.ioMode == FTI_IO_POSIX ) {
-                    if (rename(FTI_Ckpt[FTI_Exec.lastCkptLvel].metaDir, FTI_Ckpt[4].metaDir) == -1) {
-                        FTI_Print("cannot save last ckpt. metaDir", FTI_EROR);
-                    }
-                } else {
-                    if (rename(FTI_Conf.mTmpDir, FTI_Ckpt[4].metaDir) == -1) {
-                        FTI_Print("cannot save last ckpt. metaDir", FTI_EROR);
-                    }
+                if (rename(FTI_Ckpt[FTI_Exec.lastCkptLvel].metaDir, FTI_Ckpt[4].metaDir) == -1) {
+                    FTI_Print("cannot save last ckpt. metaDir", FTI_EROR);
                 }
                 if (rename(FTI_Conf.gTmpDir, FTI_Ckpt[4].dir) == -1) {
                     FTI_Print("cannot save last ckpt. dir", FTI_EROR);
@@ -593,6 +631,7 @@ int FTI_Finalize()
         }
         buff = 5; // For cleaning everything
     }
+    FTI_FreeMeta(&FTI_Exec);
     MPI_Barrier(FTI_Exec.globalComm);
     FTI_Try(FTI_Clean(&FTI_Conf, &FTI_Topo, FTI_Ckpt, buff, FTI_Topo.groupID, FTI_Topo.myRank), "do final clean.");
     FTI_Print("FTI has been finalized.", FTI_INFO);

--- a/src/api.c
+++ b/src/api.c
@@ -71,48 +71,6 @@ void FTI_Abort()
 
 /*-------------------------------------------------------------------------*/
 /**
-    @brief      It prints the metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-
-    This function prints the metadata for each process.
-
- **/
-/*-------------------------------------------------------------------------*/
-void FTI_PrintMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo)
-{
-    int i, j, k;
-    char str[FTI_BUFS];
-    for (i = 0; i < FTI_Topo->nbProc; i++) {
-        if (FTI_Topo->myRank == i) {
-            if (FTI_Topo->amIaHead) {
-                sprintf(str, "I am a head. Node: %d, Group: %d", FTI_Topo->nodeID, FTI_Topo->groupID);
-                FTI_Print(str, FTI_WARN);
-                for (j = 1; j < FTI_Topo->nodeSize; j++) {
-                    for (k = 0; k < 5; k++) {
-                        sprintf(str, "Approcs %d: Level: %d; Exists: %d; fs: %ld; maxFs: %ld, pfs: %ld; ckptFile: %s",
-                                j, k, FTI_Exec->meta[k].exists[j], FTI_Exec->meta[k].fs[j], FTI_Exec->meta[k].maxFs[j],
-                                FTI_Exec->meta[k].pfs[j], &FTI_Exec->meta[k].ckptFile[j * FTI_BUFS]);
-                        FTI_Print(str, FTI_WARN);
-                    }
-                }
-            }
-            else {
-                for (k = 0; k < 5; k++) {
-                    sprintf(str, "Level: %d; Exists: %d; fs: %ld; maxFs: %ld, pfs: %ld; ckptFile: %s",
-                            k, FTI_Exec->meta[k].exists[0], FTI_Exec->meta[k].fs[0], FTI_Exec->meta[k].maxFs[0],
-                            FTI_Exec->meta[k].pfs[0], FTI_Exec->meta[k].ckptFile);
-                    FTI_Print(str, FTI_WARN);
-                }
-            }
-        }
-        MPI_Barrier(FTI_COMM_WORLD);
-    }
-}
-
-
-/*-------------------------------------------------------------------------*/
-/**
     @brief      Initializes FTI.
     @param      configFile      FTI configuration file.
     @param      globalComm      Main MPI communicator of the application.

--- a/src/interface.h
+++ b/src/interface.h
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 #include "../deps/md5/md5.h"
-#define MD5_DIGEST_LENGTH 17    /**< Hashed string length.          */
 
 #include <sys/stat.h>
 #include <string.h>
@@ -44,7 +43,7 @@
 /*---------------------------------------------------------------------------
                             FTI private functions
 ---------------------------------------------------------------------------*/
-
+void FTI_PrintMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo);
 void FTI_Abort();
 int FTI_FloatBitFlip(float *target, int bit);
 int FTI_DoubleBitFlip(double *target, int bit);
@@ -58,12 +57,13 @@ int FTI_WriteCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_WriteSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 FTIT_topology* FTI_Topo,FTIT_dataset* FTI_Data);
 #endif
-int FTI_WriteMpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+int FTI_WriteMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 FTIT_topology* FTI_Topo,FTIT_dataset* FTI_Data);
 int FTI_WritePar(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 FTIT_topology* FTI_Topo,FTIT_dataset* FTI_Data);
-int FTI_WriteSer(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-        FTIT_topology* FTI_Topo,FTIT_dataset* FTI_Data);
+int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+                    FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
+                    FTIT_dataset* FTI_Data);
 int FTI_GroupClean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
                    FTIT_checkpoint* FTI_Ckpt, int level, int group, int pr);
 int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
@@ -94,53 +94,43 @@ int FTI_WriteRSedChecksum(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec
                               int rank, char* checksum);
 int FTI_GetPtnerSize(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
                       FTIT_checkpoint* FTI_Ckpt, unsigned long* pfs, int group, int level);
-int FTI_GetMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
-                unsigned long *fs, unsigned long *mfs, int group, int level);
+int FTI_LoadTmpMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
+int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
-                      unsigned long *fs, unsigned long mfs, char* fnl, char* checksums, int member);
+                      unsigned long *fs, unsigned long mfs, char* fnl, char* checksums);
 int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                       FTIT_topology* FTI_Topo, int globalTmp, int member);
+                       FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 
 int FTI_Local(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_Ptner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
-int FTI_FlushInit(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
-int FTI_FlushInitPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-int FTI_FlushInitSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
-#endif
-int FTI_FlushInitMpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group, int level);
-int FTI_FlushFinalize(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
               FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
-int FTI_FlushFinalizeMpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
+int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
+int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
 #ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-int FTI_FlushFinalizeSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
+int FTI_FlushSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+                    FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level);
 #endif
 int FTI_Decode(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-               FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
-               int fs, int maxFs, int *erased);
+               FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int *erased);
 int FTI_RecoverL1(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_RecoverL4(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group);
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                   FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 #ifdef ENABLE_SIONLIB // --> If SIONlib is installed
@@ -150,14 +140,15 @@ int FTI_RecoverL4Sionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_CheckFile(char *fn, unsigned long fs, char* checksum);
 int FTI_CheckErasures(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                       FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
-                      unsigned long *fs, unsigned long *maxFs, int group,
-                      int *erased, int level);
+                      int *erased);
 int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 
 int FTI_Checksum(char* fileName, char* checksum);
 int FTI_VerifyChecksum(char* fileName, char* checksumToCmp);
 int FTI_Try(int result, char* message);
+void FTI_MallocMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo);
+void FTI_FreeMeta(FTIT_execution* FTI_Exec);
 int FTI_InitBasicTypes(FTIT_dataset* FTI_Data);
 int FTI_RmDir(char path[FTI_BUFS], int flag);
 int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -14,7 +14,6 @@
   @param      FTI_Exec        Execution metadata.
   @param      FTI_Topo        Topology metadata.
   @param      FTI_Ckpt        Checkpoint metadata.
-  @param      group           The group ID.
   @return     integer         FTI_SCES.
 
   This function just returns FTI_SCES to have homogeneous code.
@@ -22,14 +21,9 @@
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_Local(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-    unsigned long maxFs, fs;
     FTI_Print("Starting checkpoint post-processing L1", FTI_DBUG);
-    int res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, 0), "obtain metadata.");
-    if (res == FTI_NSCS) {
-        return FTI_NSCS;
-    }
     return FTI_SCES;
 }
 
@@ -39,8 +33,8 @@ int FTI_Local(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
   @param      FTI_Conf        Configuration metadata.
   @param      FTI_Exec        Execution metadata.
   @param      FTI_Ckpt        Checkpoint metadata.
-  @param      fs              Ckpt file size
   @param      destination     destination group rank
+  @param      postFlag        0 if postckpt done by approc, > 0 if by head
   @return     integer         FTI_SCES if successful.
 
   This function sends ckpt file to partner process. Partner should call
@@ -49,15 +43,20 @@ int FTI_Local(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_SendCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_checkpoint* FTI_Ckpt,
-                 unsigned long fs, int destination)
+                 int destination, int postFlag)
 {
     int bytes; //bytes read by fread
     char lfn[FTI_BUFS], str[FTI_BUFS];
     FILE* lfd;
 
-    sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->ckptFile);
+    sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[postFlag * FTI_BUFS]);
 
-    sprintf(str, "L2 trying to access local ckpt. file (%s).", lfn);
+    if (postFlag) {
+        sprintf(str, "L2 trying to access process's %d ckpt. file (%s).", postFlag, lfn);
+    }
+    else {
+        sprintf(str, "L2 trying to access local ckpt. file (%s).", lfn);
+    }
     FTI_Print(str, FTI_DBUG);
 
     lfd = fopen(lfn, "rb");
@@ -67,7 +66,7 @@ int FTI_SendCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_ch
     }
 
     char* buffer = talloc(char, FTI_Conf->blockSize);
-    unsigned long toSend = fs; //remaining data to send
+    long toSend = FTI_Exec->meta[0].fs[postFlag]; //remaining data to send
     while (toSend > 0) {
         int sendSize = (toSend > FTI_Conf->blockSize) ? FTI_Conf->blockSize : toSend;
         bytes = fread(buffer, sizeof(char), sendSize, lfd);
@@ -97,8 +96,8 @@ int FTI_SendCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_ch
   @param      FTI_Conf        Configuration metadata.
   @param      FTI_Exec        Execution metadata.
   @param      FTI_Ckpt        Checkpoint metadata.
-  @param      pfs             Ptner file size
   @param      source          souce group rank
+  @param      postFlag        0 if postckpt done by approc, > 0 if by head
   @return     integer         FTI_SCES if successful.
 
   This function receives ckpt file from partner process and saves it as
@@ -107,14 +106,14 @@ int FTI_SendCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_ch
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_checkpoint* FTI_Ckpt,
-                  unsigned long pfs, int source)
+                  int source, int postFlag)
 {
-    int rank;
+    int ckptID, rank;
     char pfn[FTI_BUFS], str[FTI_BUFS];
 
     //heads need to use ckptFile to get ckptID and rank
-    sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &rank);
-    sprintf(pfn, "%s/Ckpt%d-Pcof%d.fti", FTI_Conf->lTmpDir, FTI_Exec->ckptID, rank);
+    sscanf(&FTI_Exec->meta[0].ckptFile[postFlag * FTI_BUFS], "Ckpt%d-Rank%d.fti", &ckptID, &rank);
+    sprintf(pfn, "%s/Ckpt%d-Pcof%d.fti", FTI_Conf->lTmpDir, ckptID, rank);
     sprintf(str, "L2 trying to access Ptner file (%s).", pfn);
     FTI_Print(str, FTI_DBUG);
 
@@ -125,7 +124,7 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
     }
 
     char* buffer = talloc(char, FTI_Conf->blockSize);
-    unsigned long toRecv = pfs; //remaining data to receive
+    unsigned long toRecv = FTI_Exec->meta[0].pfs[postFlag]; //remaining data to receive
     while (toRecv > 0) {
         int recvSize = (toRecv > FTI_Conf->blockSize) ? FTI_Conf->blockSize : toRecv;
         MPI_Recv(buffer, recvSize, MPI_CHAR, source, FTI_Conf->tag, FTI_Exec->groupComm, MPI_STATUS_IGNORE);
@@ -155,7 +154,6 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
   @param      FTI_Exec        Execution metadata.
   @param      FTI_Topo        Topology metadata.
   @param      FTI_Ckpt        Checkpoint metadata.
-  @param      group           The group ID.
   @return     integer         FTI_SCES if successful.
 
   This function copies the checkpoint files into the partner node. It
@@ -165,41 +163,42 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_Ptner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-    unsigned long maxFs, fs, pfs; //ckpt file size, partner file size
     int source = FTI_Topo->left; //receive Ckpt file from this process
     int destination = FTI_Topo->right; //send Ckpt file to this process
     int res;
-
     FTI_Print("Starting checkpoint post-processing L2", FTI_DBUG);
-    res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, 0), "obtain metadata.");
-    if (res == FTI_NSCS) {
-        return FTI_NSCS;
+    FTI_LoadTmpMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+    int startProc, endProc;
+    if (FTI_Topo->amIaHead) { //post-processing for every process in the node
+        startProc = 1;
+        endProc = FTI_Topo->nodeSize;
     }
-
-    res = FTI_GetPtnerSize(FTI_Conf, FTI_Topo, FTI_Ckpt, &pfs, group, 0);
-    if (res == FTI_NSCS) {
-        return FTI_NSCS;
+    else { //post-processing only for itself
+        startProc = 0;
+        endProc = 1;
     }
-
-    if (FTI_Topo->groupRank % 2) { //first send, then receive
-        res = FTI_SendCkpt(FTI_Conf, FTI_Exec, FTI_Ckpt, fs, destination);
-        if (res != FTI_SCES) {
-            return FTI_NSCS;
-        }
-        res = FTI_RecvPtner(FTI_Conf, FTI_Exec, FTI_Ckpt, pfs, source);
-        if (res != FTI_SCES) {
-            return FTI_NSCS;
-        }
-    } else { //first receive, then send
-        res = FTI_RecvPtner(FTI_Conf, FTI_Exec, FTI_Ckpt, pfs, source);
-        if (res != FTI_SCES) {
-            return FTI_NSCS;
-        }
-        res = FTI_SendCkpt(FTI_Conf, FTI_Exec, FTI_Ckpt, fs, destination);
-        if (res != FTI_SCES) {
-            return FTI_NSCS;
+    int i;
+    for (i = startProc; i < endProc; i++) {
+        if (FTI_Topo->groupRank % 2) { //first send, then receive
+            res = FTI_SendCkpt(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, i);
+            if (res != FTI_SCES) {
+                return FTI_NSCS;
+            }
+            res = FTI_RecvPtner(FTI_Conf, FTI_Exec, FTI_Ckpt, source, i);
+            if (res != FTI_SCES) {
+                return FTI_NSCS;
+            }
+        } else { //first receive, then send
+            res = FTI_RecvPtner(FTI_Conf, FTI_Exec, FTI_Ckpt, source, i);
+            if (res != FTI_SCES) {
+                return FTI_NSCS;
+            }
+            res = FTI_SendCkpt(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, i);
+            if (res != FTI_SCES) {
+                return FTI_NSCS;
+            }
         }
     }
     return FTI_SCES;
@@ -212,7 +211,6 @@ int FTI_Ptner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
   @param      FTI_Exec        Execution metadata.
   @param      FTI_Topo        Topology metadata.
   @param      FTI_Ckpt        Checkpoint metadata.
-  @param      group           The group ID.
   @return     integer         FTI_SCES if successful.
 
   This function performs the Reed-Solomon encoding for a given group. The
@@ -222,7 +220,7 @@ int FTI_Ptner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
     char *myData, *data, *coding, lfn[FTI_BUFS], efn[FTI_BUFS], str[FTI_BUFS];
     int *matrix, cnt, i, j, init, src, offset, dest, matVal, res, bs = FTI_Conf->blockSize, rank;
@@ -233,151 +231,169 @@ int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FILE *lfd, *efd;
 
     FTI_Print("Starting checkpoint post-processing L3", FTI_DBUG);
-    res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, 0), "obtain metadata.");
+    res = FTI_Try(FTI_LoadTmpMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt), "load temporary metadata.");
     if (res != FTI_SCES) {
         return FTI_NSCS;
     }
-    ps = ((maxFs / bs)) * bs;
-    if (ps < maxFs) {
-        ps = ps + bs;
+
+    int startProc, endProc;
+    if (FTI_Topo->amIaHead) {
+        startProc = 1;
+        endProc = FTI_Topo->nodeSize;
+    }
+    else {
+        startProc = 0;
+        endProc = 1;
     }
 
-    sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &rank);
-    sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->ckptFile);
-    sprintf(efn, "%s/Ckpt%d-RSed%d.fti", FTI_Conf->lTmpDir, FTI_Exec->ckptID, rank);
+    int proc;
+    for (proc = startProc; proc < endProc; proc++) {
+        long fs = FTI_Exec->meta[0].fs[proc]; //ckpt file size
+        long maxFs = FTI_Exec->meta[0].maxFs[proc]; //max file size in group
 
-    sprintf(str, "L3 trying to access local ckpt. file (%s).", lfn);
-    FTI_Print(str, FTI_DBUG);
-
-    //all files in group must have the same size
-    if (truncate(lfn, maxFs) == -1) {
-        FTI_Print("Error with truncate on checkpoint file", FTI_WARN);
-        return FTI_NSCS;
-    }
-
-    lfd = fopen(lfn, "rb");
-    if (lfd == NULL) {
-        FTI_Print("FTI failed to open L3 checkpoint file.", FTI_EROR);
-        return FTI_NSCS;
-    }
-
-    efd = fopen(efn, "wb");
-    if (efd == NULL) {
-        FTI_Print("FTI failed to open encoded ckpt. file.", FTI_EROR);
-
-        fclose(lfd);
-
-        return FTI_NSCS;
-    }
-
-    myData = talloc(char, bs);
-    coding = talloc(char, bs);
-    data = talloc(char, 2 * bs);
-    matrix = talloc(int, FTI_Topo->groupSize* FTI_Topo->groupSize);
-
-    for (i = 0; i < FTI_Topo->groupSize; i++) {
-        for (j = 0; j < FTI_Topo->groupSize; j++) {
-            matrix[i * FTI_Topo->groupSize + j] = galois_single_divide(1, i ^ (FTI_Topo->groupSize + j), FTI_Conf->l3WordSize);
-        }
-    }
-
-    // For each block
-    while (pos < ps) {
-        if ((maxFs - pos) < bs) {
-            remBsize = maxFs - pos;
+        ps = ((maxFs / bs)) * bs;
+        if (ps < maxFs) {
+            ps = ps + bs;
         }
 
-        // Reading checkpoint files
-        size_t bytes = fread(myData, sizeof(char), remBsize, lfd);
-        if (ferror(lfd)) {
-            FTI_Print("FTI failed to read from L3 ckpt. file.", FTI_EROR);
+        sscanf(&FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS], "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &rank);
+        sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+        sprintf(efn, "%s/Ckpt%d-RSed%d.fti", FTI_Conf->lTmpDir, FTI_Exec->ckptID, rank);
 
-            free(data);
-            free(matrix);
-            free(coding);
-            free(myData);
+        sprintf(str, "L3 trying to access local ckpt. file (%s).", lfn);
+        FTI_Print(str, FTI_DBUG);
+
+        //all files in group must have the same size
+        if (truncate(lfn, maxFs) == -1) {
+            FTI_Print("Error with truncate on checkpoint file", FTI_WARN);
+            return FTI_NSCS;
+        }
+
+        lfd = fopen(lfn, "rb");
+        if (lfd == NULL) {
+            FTI_Print("FTI failed to open L3 checkpoint file.", FTI_EROR);
+            return FTI_NSCS;
+        }
+
+        efd = fopen(efn, "wb");
+        if (efd == NULL) {
+            FTI_Print("FTI failed to open encoded ckpt. file.", FTI_EROR);
+
             fclose(lfd);
-            fclose(efd);
 
             return FTI_NSCS;
         }
 
-        dest = FTI_Topo->groupRank;
-        i = FTI_Topo->groupRank;
-        offset = 0;
-        init = 0;
-        cnt = 0;
+        myData = talloc(char, bs);
+        coding = talloc(char, bs);
+        data = talloc(char, 2 * bs);
+        matrix = talloc(int, FTI_Topo->groupSize* FTI_Topo->groupSize);
 
-        // For each encoding
-        while (cnt < FTI_Topo->groupSize) {
-            if (cnt == 0) {
-                memcpy(&(data[offset * bs]), myData, sizeof(char) * bytes);
+        for (i = 0; i < FTI_Topo->groupSize; i++) {
+            for (j = 0; j < FTI_Topo->groupSize; j++) {
+                matrix[i * FTI_Topo->groupSize + j] = galois_single_divide(1, i ^ (FTI_Topo->groupSize + j), FTI_Conf->l3WordSize);
             }
-            else {
-                MPI_Wait(&reqSend, &status);
-                MPI_Wait(&reqRecv, &status);
-            }
-
-            // At every loop *but* the last one we send the data
-            if (cnt != FTI_Topo->groupSize - 1) {
-                dest = (dest + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize;
-                src = (i + 1) % FTI_Topo->groupSize;
-                MPI_Isend(myData, bytes, MPI_CHAR, dest, FTI_Conf->tag, FTI_Exec->groupComm, &reqSend);
-                MPI_Irecv(&(data[(1 - offset) * bs]), bs, MPI_CHAR, src, FTI_Conf->tag, FTI_Exec->groupComm, &reqRecv);
-            }
-
-            matVal = matrix[FTI_Topo->groupRank * FTI_Topo->groupSize + i];
-            // First copy or xor any data that does not need to be multiplied by a factor
-            if (matVal == 1) {
-                if (init == 0) {
-                    memcpy(coding, &(data[offset * bs]), bs);
-                    init = 1;
-                }
-                else {
-                    galois_region_xor(&(data[offset * bs]), coding, coding, bs);
-                }
-            }
-
-            // Then the data that needs to be multiplied by a factor
-            if (matVal != 0 && matVal != 1) {
-                galois_w16_region_multiply(&(data[offset * bs]), matVal, bs, coding, init);
-                init = 1;
-            }
-
-            i = (i + 1) % FTI_Topo->groupSize;
-            offset = 1 - offset;
-            cnt++;
         }
 
-        // Writting encoded checkpoints
-        fwrite(coding, sizeof(char), remBsize, efd);
+        // For each block
+        while (pos < ps) {
+            if ((maxFs - pos) < bs) {
+                remBsize = maxFs - pos;
+            }
 
-        // Next block
-        pos = pos + bs;
+            // Reading checkpoint files
+            size_t bytes = fread(myData, sizeof(char), remBsize, lfd);
+            if (ferror(lfd)) {
+                FTI_Print("FTI failed to read from L3 ckpt. file.", FTI_EROR);
+
+                free(data);
+                free(matrix);
+                free(coding);
+                free(myData);
+                fclose(lfd);
+                fclose(efd);
+
+                return FTI_NSCS;
+            }
+
+            dest = FTI_Topo->groupRank;
+            i = FTI_Topo->groupRank;
+            offset = 0;
+            init = 0;
+            cnt = 0;
+
+            // For each encoding
+            while (cnt < FTI_Topo->groupSize) {
+                if (cnt == 0) {
+                    memcpy(&(data[offset * bs]), myData, sizeof(char) * bytes);
+                }
+                else {
+                    MPI_Wait(&reqSend, &status);
+                    MPI_Wait(&reqRecv, &status);
+                }
+
+                // At every loop *but* the last one we send the data
+                if (cnt != FTI_Topo->groupSize - 1) {
+                    dest = (dest + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize;
+                    src = (i + 1) % FTI_Topo->groupSize;
+                    MPI_Isend(myData, bytes, MPI_CHAR, dest, FTI_Conf->tag, FTI_Exec->groupComm, &reqSend);
+                    MPI_Irecv(&(data[(1 - offset) * bs]), bs, MPI_CHAR, src, FTI_Conf->tag, FTI_Exec->groupComm, &reqRecv);
+                }
+
+                matVal = matrix[FTI_Topo->groupRank * FTI_Topo->groupSize + i];
+                // First copy or xor any data that does not need to be multiplied by a factor
+                if (matVal == 1) {
+                    if (init == 0) {
+                        memcpy(coding, &(data[offset * bs]), bs);
+                        init = 1;
+                    }
+                    else {
+                        galois_region_xor(&(data[offset * bs]), coding, coding, bs);
+                    }
+                }
+
+                // Then the data that needs to be multiplied by a factor
+                if (matVal != 0 && matVal != 1) {
+                    galois_w16_region_multiply(&(data[offset * bs]), matVal, bs, coding, init);
+                    init = 1;
+                }
+
+                i = (i + 1) % FTI_Topo->groupSize;
+                offset = 1 - offset;
+                cnt++;
+            }
+
+            // Writting encoded checkpoints
+            fwrite(coding, sizeof(char), remBsize, efd);
+
+            // Next block
+            pos = pos + bs;
+        }
+
+        free(data);
+        free(matrix);
+        free(coding);
+        free(myData);
+        fclose(lfd);
+        fclose(efd);
+
+        if (truncate(lfn, fs) == -1) {
+            FTI_Print("Error with re-truncate on checkpoint file", FTI_WARN);
+            return FTI_NSCS;
+        }
+
+        //write checksum in metadata
+        char checksum[MD5_DIGEST_LENGTH];
+        res = FTI_Checksum(efn, checksum);
+        if (res != FTI_SCES) {
+            return FTI_NSCS;
+        }
+        res = FTI_WriteRSedChecksum(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, rank, checksum);
     }
-
-    free(data);
-    free(matrix);
-    free(coding);
-    free(myData);
-    fclose(lfd);
-    fclose(efd);
-
-    if (truncate(lfn, fs) == -1) {
-        FTI_Print("Error with re-truncate on checkpoint file", FTI_WARN);
-        return FTI_NSCS;
-    }
-
-    //write checksum in metadata
-    char checksum[MD5_DIGEST_LENGTH];
-    res = FTI_Checksum(efn, checksum);
-    if (res != FTI_SCES) {
-        return FTI_NSCS;
-    }
-    res = FTI_WriteRSedChecksum(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, rank, checksum);
 
     return res;
 }
+
 
 /*-------------------------------------------------------------------------*/
 /**
@@ -386,706 +402,457 @@ int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
   @param      FTI_Exec        Execution metadata.
   @param      FTI_Topo        Topology metadata.
   @param      FTI_Ckpt        Checkpoint metadata.
-  @param      group           The group ID.
   @param      level           The level from which ckpt. files are flushed.
   @return     integer         FTI_SCES if successful.
 
   This function flushes the local checkpoint files in to the PFS.
 
  **/
-/*-------------------------------------------------------------------------*/
+ /*-------------------------------------------------------------------------*/
 int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group, int level)
+                FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
 {
-   int i, res, gRank, member, reslen;
-   char lfn[FTI_BUFS], gfn[FTI_BUFS], str[FTI_BUFS], mpi_err[FTI_BUFS];
-   unsigned long ps, pos = 0;
-   FILE *lfd;
-   FILE *gfd;
-   MPI_Datatype dType;
-   MPI_Status status;
-   MPI_Offset *chunkSizes, *lChunkSizes, offset = 0;
-
-   if (level == -1 || (level != -1 && FTI_Topo->amIaHead && FTI_Ckpt[4].isInline )) {
-      return FTI_SCES; // Fake call for inline PFS checkpoint
-   }
-
-   FTI_Print("Starting checkpoint post-processing L4", FTI_DBUG);
-
-   // assign index for metadata
-   member = (FTI_Topo->amIaHead) ? group-1 : 0;
-
-   // determine rank
-   gRank = (FTI_Topo->amIaHead) ? FTI_Topo->body[member] : FTI_Topo->myRank;
-
-   // determine number of members
-   int nbMembers = (FTI_Topo->amIaHead) ? FTI_Topo->nbApprocs : 1;
-
-   // determine split rank from global rank
-   int splitRank = (FTI_Topo->amIaHead) ? gRank - ( (FTI_Topo->splitRank+1) * FTI_Topo->nbHeads ) : FTI_Topo->splitRank;
-
-   // align ps to blocksize
-   ps = (FTI_Exec->meta[member].maxFs / FTI_Conf->transferSize) * FTI_Conf->transferSize;
-   if (ps < FTI_Exec->meta[member].maxFs) {
-      ps = ps + FTI_Conf->transferSize;
-   }
-
-   switch (level) {
-      case 0:
-         sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->meta[member].ckptFile);
-         break;
-      case 1:
-         sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->meta[member].ckptFile);
-         break;
-      case 2:
-         sprintf(lfn, "%s/%s", FTI_Ckpt[2].dir, FTI_Exec->meta[member].ckptFile);
-         break;
-      case 3:
-         sprintf(lfn, "%s/%s", FTI_Ckpt[3].dir, FTI_Exec->meta[member].ckptFile);
-         break;
-   }
-
-   sprintf(str, "L4 trying to access local ckpt. file (%s).", lfn);
-   FTI_Print(str, FTI_DBUG);
-
-   // Open local file
-   lfd = fopen(lfn, "rb");
-   if (lfd == NULL) {
-      FTI_Print("L4 cannot open the checkpoint file.", FTI_EROR);
-      return FTI_NSCS;
-   }
-
-   // select behaviour depending on I/O
-   switch (FTI_Conf->ioMode) {
-
-      case FTI_IO_POSIX:
-
-         sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, FTI_Exec->meta[member].ckptFile);
-         gfd = fopen(gfn, "wb");
-
-         if (gfd == NULL) {
-            FTI_Print("L4 cannot open ckpt. file in the PFS.", FTI_EROR);
-            fclose(lfd);
-            return FTI_NSCS;
-         }
-
-         break;
-
-      case FTI_IO_MPI:
-
-         // collect chunksizes of other ranks
-         lChunkSizes = talloc(MPI_Offset, nbMembers);
-         for (i = 0; i < nbMembers; i++) {
-            lChunkSizes[i] = FTI_Exec->meta[i].fs;
-         }
-
-         chunkSizes = talloc(MPI_Offset, FTI_Topo->nbApprocs*FTI_Topo->nbNodes);
-         MPI_Allgather(lChunkSizes, nbMembers, MPI_OFFSET, chunkSizes, nbMembers, MPI_OFFSET, FTI_COMM_WORLD);
-
-         // set file offset
-         for (i=0; i<splitRank; i++) {
-            offset += chunkSizes[i];
-         }
-
-         free(lChunkSizes);
-         free(chunkSizes);
-
-         break;
-
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-      case FTI_IO_SIONLIB:
-
-         res = sion_seek(FTI_Exec->sid, gRank, SION_CURRENT_BLK, SION_CURRENT_POS);
-
-         if (res!=SION_SUCCESS) {
-            errno = 0;
-            sprintf(str, "SIONlib: unable to set file pointer");
-            FTI_Print(str, FTI_EROR);
-            fclose(lfd);
-            sion_parclose_mapped_mpi(FTI_Exec->sid);
-            return FTI_NSCS;
-         }
-
-         break;
-#endif
-   }
-
-   char *blBuf1 = talloc(char, FTI_Conf->transferSize);
-   unsigned long bSize = FTI_Conf->transferSize;
-
-   // Checkpoint files exchange
-   while (pos < ps) {
-      if ((FTI_Exec->meta[member].fs - pos) < FTI_Conf->transferSize)
-         bSize = FTI_Exec->meta[member].fs - pos;
-
-      size_t bytes = fread(blBuf1, sizeof(char), bSize, lfd);
-      if (ferror(lfd)) {
-         FTI_Print("L4 cannot read from the ckpt. file.", FTI_EROR);
-         free(blBuf1);
-         fclose(lfd);
-         switch (FTI_Conf->ioMode) {
-            case FTI_IO_POSIX:
-               fclose(gfd);
-               break;
+    if (level == -1) {
+       return FTI_SCES; // Fake call for inline PFS checkpoint
+    }
+    char str[FTI_BUFS];
+    sprintf(str, "Starting checkpoint post-processing L4 for level %d", level);
+    FTI_Print(str, FTI_DBUG);
+    // create global temp directory
+    if (mkdir(FTI_Conf->gTmpDir, 0777) == -1) {
+       if (errno != EEXIST) {
+          FTI_Print("Cannot create global directory", FTI_EROR);
+          return FTI_NSCS;
+       }
+    }
+    int res = FTI_Try(FTI_LoadMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt), "load metadata.");
+    if (res != FTI_SCES) {
+        return FTI_NSCS;
+    }
+    if (!FTI_Ckpt[4].isInline || FTI_Conf->ioMode == FTI_IO_POSIX) {
+        res = FTI_FlushPosix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
+    }
+    else {
+        switch(FTI_Conf->ioMode) {
             case FTI_IO_MPI:
-               MPI_File_close(&FTI_Exec->pfh);
-               break;
+                FTI_FlushMPI(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
+                break;
 #ifdef ENABLE_SIONLIB // --> If SIONlib is installed
             case FTI_IO_SIONLIB:
-               sion_parclose_mapped_mpi(FTI_Exec->sid);
-               break;
+                FTI_FlushSionlib(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
+                break;
 #endif
-         }
-         return FTI_NSCS;
-      }
+        }
+    }
+    return FTI_SCES;
+}
 
-      switch (FTI_Conf->ioMode) {
+/*-------------------------------------------------------------------------*/
+/**
+    @brief      It flushes the local ckpt. files in to the PFS using POSIX.
+    @param      FTI_Conf        Configuration metadata.
+    @param      FTI_Exec        Execution metadata.
+    @param      FTI_Topo        Topology metadata.
+    @param      FTI_Ckpt        Checkpoint metadata.
+    @param      level           The level from which ckpt. files are flushed.
+    @return     integer         FTI_SCES if successful.
 
-         case FTI_IO_POSIX:
+    This function flushes the local checkpoint files in to the PFS.
 
-            fwrite(blBuf1, sizeof(char), bytes, gfd);
+ **/
+/*-------------------------------------------------------------------------*/
+int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+                    FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
+{
+    FTI_Print("Starting checkpoint post-processing L4 using Posix IO.", FTI_DBUG);
+    int startProc, endProc, proc;
+    if (FTI_Topo->amIaHead) {
+        startProc = 1;
+        endProc = FTI_Topo->nodeSize;
+    }
+    else {
+        startProc = 0;
+        endProc = 1;
+    }
+
+    for (proc = startProc; proc < endProc; proc++) {
+        char str[FTI_BUFS];
+        sprintf(str, "Post-processing for proc %d started.", proc);
+        FTI_Print(str, FTI_DBUG);
+        char lfn[FTI_BUFS], gfn[FTI_BUFS];
+        sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+        sprintf(str, "Global temporary file name for proc %d: %s", proc, gfn);
+        FTI_Print(str, FTI_DBUG);
+        FILE* gfd = fopen(gfn, "wb");
+
+        if (gfd == NULL) {
+           FTI_Print("L4 cannot open ckpt. file in the PFS.", FTI_EROR);
+           return FTI_NSCS;
+        }
+
+        if (level == 0) {
+            sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+        }
+        else {
+            sprintf(lfn, "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+        }
+        sprintf(str, "Local file name for proc %d: %s", proc, lfn);
+        FTI_Print(str, FTI_DBUG);
+        // Open local file
+        FILE* lfd = fopen(lfn, "rb");
+        if (lfd == NULL) {
+            FTI_Print("L4 cannot open the checkpoint file.", FTI_EROR);
+            fclose(gfd);
+            return FTI_NSCS;
+        }
+
+        char *readData = talloc(char, FTI_Conf->transferSize);
+        long bSize = FTI_Conf->transferSize;
+        long fs = FTI_Exec->meta[level].fs[proc];
+        sprintf(str, "Local file size for proc %d: %ld", proc, fs);
+        FTI_Print(str, FTI_DBUG);
+        long pos = 0;
+        // Checkpoint files exchange
+        while (pos < fs) {
+            if ((fs - pos) < FTI_Conf->transferSize)
+              bSize = fs - pos;
+
+            size_t bytes = fread(readData, sizeof(char), bSize, lfd);
+            if (ferror(lfd)) {
+                FTI_Print("L4 cannot read from the ckpt. file.", FTI_EROR);
+                free(readData);
+                fclose(lfd);
+                fclose(gfd);
+                return FTI_NSCS;
+           }
+
+            fwrite(readData, sizeof(char), bytes, gfd);
             if (ferror(gfd)) {
-               FTI_Print("L4 cannot write to the ckpt. file in the PFS.", FTI_EROR);
-               free(blBuf1);
-               fclose(lfd);
-               fclose(gfd);
-               return FTI_NSCS;
+                FTI_Print("L4 cannot write to the ckpt. file in the PFS.", FTI_EROR);
+                free(readData);
+                fclose(lfd);
+                fclose(gfd);
+                return FTI_NSCS;
+            }
+            pos = pos + bytes;
+        }
+        free(readData);
+        fclose(lfd);
+        fclose(gfd);
+    }
+    return FTI_SCES;
+}
+
+/*-------------------------------------------------------------------------*/
+/**
+    @brief      It flushes the local ckpt. files in to the PFS using MPI-I/O.
+    @param      FTI_Conf        Configuration metadata.
+    @param      FTI_Exec        Execution metadata.
+    @param      FTI_Topo        Topology metadata.
+    @param      FTI_Ckpt        Checkpoint metadata.
+    @param      level           The level from which ckpt. files are flushed.
+    @return     integer         FTI_SCES if successful.
+
+    This function flushes the local checkpoint files in to the PFS.
+
+ **/
+/*-------------------------------------------------------------------------*/
+int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+                    FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
+{
+    FTI_Print("Starting checkpoint post-processing L4 using MPI-IO.", FTI_DBUG);
+    // enable collective buffer optimization
+    MPI_Info info;
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "romio_cb_write", "enable");
+    // TODO enable to set stripping unit in the config file (Maybe also other hints)
+    // set stripping unit to 4MB
+    MPI_Info_set(info, "stripping_unit", "4194304");
+
+    // open parallel file (collective call)
+    MPI_File pfh; // MPI-IO file handle
+    char gfn[FTI_BUFS], lfn[FTI_BUFS], str[FTI_BUFS];
+    snprintf(str, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
+    sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, str);
+    int res = MPI_File_open(FTI_COMM_WORLD, gfn, MPI_MODE_WRONLY|MPI_MODE_CREATE, info, &pfh);
+    if (res != 0) {
+       errno = 0;
+       char mpi_err[FTI_BUFS];
+       int reslen;
+       MPI_Error_string(res, mpi_err, &reslen);
+       snprintf(str, FTI_BUFS, "Unable to create file during MPI-IO flush [MPI ERROR - %i] %s", res, mpi_err);
+       FTI_Print(str, FTI_EROR);
+       MPI_Info_free(&info);
+       return FTI_NSCS;
+    }
+    MPI_Info_free(&info);
+
+    int proc, startProc, endProc;
+    if (FTI_Topo->amIaHead) {
+        startProc = 1;
+        endProc = FTI_Topo->nodeSize;
+    }
+    else {
+        startProc = 0;
+        endProc = 1;
+    }
+    int nbProc = endProc - startProc;
+    MPI_Offset* localFileSizes = talloc(MPI_Offset, nbProc);
+    char* localFileNames = talloc(char, FTI_BUFS * endProc);
+    int* splitRanks = talloc(int, endProc); //rank of process in FTI_COMM_WORLD
+    for (proc = startProc; proc < endProc; proc++) {
+        if (level == 0) {
+            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+        }
+        else {
+            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+        }
+        if (FTI_Topo->amIaHead) {
+            splitRanks[proc] = (FTI_Topo->nodeSize - 1) * FTI_Topo->nodeID + proc - 1;
+        }
+        else {
+            splitRanks[proc] = FTI_Topo->splitRank;
+        }
+        localFileSizes[proc - startProc] = FTI_Exec->meta[level].fs[proc]; //[proc - startProc] to get index from 0
+    }
+
+    MPI_Offset* allFileSizes = talloc(MPI_Offset, FTI_Topo->nbApprocs * FTI_Topo->nbNodes);
+    MPI_Allgather(localFileSizes, nbProc, MPI_OFFSET, allFileSizes, nbProc, MPI_OFFSET, FTI_COMM_WORLD);
+    free(localFileSizes);
+
+    for (proc = startProc; proc < endProc; proc++) {
+        MPI_Offset offset = 0;
+        int i;
+        for (i = 0; i < splitRanks[proc]; i++) {
+           offset += allFileSizes[i];
+        }
+
+        FILE* lfd = fopen(&localFileNames[FTI_BUFS * proc], "rb");
+        if (lfd == NULL) {
+           FTI_Print("L4 cannot open the checkpoint file.", FTI_EROR);
+           free(localFileNames);
+           free(allFileSizes);
+           free(splitRanks);
+           return FTI_NSCS;
+        }
+
+        char* readData = talloc(char, FTI_Conf->transferSize);
+        long bSize = FTI_Conf->transferSize;
+        long fs = FTI_Exec->meta[level].fs[proc];
+
+        long pos = 0;
+        // Checkpoint files exchange
+        while (pos < fs) {
+            if ((fs - pos) < FTI_Conf->transferSize) {
+                bSize = fs - pos;
             }
 
-            break;
-
-         case FTI_IO_MPI:
-
+            size_t bytes = fread(readData, sizeof(char), bSize, lfd);
+            if (ferror(lfd)) {
+              FTI_Print("L4 cannot read from the ckpt. file.", FTI_EROR);
+              free(localFileNames);
+              free(allFileSizes);
+              free(splitRanks);
+              free(readData);
+              fclose(lfd);
+              MPI_File_close(&pfh);
+              return FTI_NSCS;
+            }
+            MPI_Datatype dType;
             MPI_Type_contiguous(bytes, MPI_BYTE, &dType);
             MPI_Type_commit(&dType);
 
-            res = MPI_File_write_at(FTI_Exec->pfh, offset, blBuf1, 1, dType, &status);
+            res = MPI_File_write_at(pfh, offset, readData, 1, dType, MPI_STATUS_IGNORE);
             // check if successful
             if (res != 0) {
-               errno = 0;
-               MPI_Error_string(res, mpi_err, &reslen);
-               snprintf(str, FTI_BUFS, "Failed to write data to PFS durin Flush [MPI ERROR - %i] %s", res, mpi_err);
-               FTI_Print(str, FTI_EROR);
-               MPI_File_close(&FTI_Exec->pfh);
-               free(blBuf1);
-               fclose(lfd);
-               return FTI_NSCS;
-            }
-
-            offset += bytes;
-            MPI_Type_free(&dType);
-
-            break;
-
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-         case FTI_IO_SIONLIB: ; //empty statement after label
-
-            long data_written = sion_fwrite(blBuf1, sizeof(char), bytes, FTI_Exec->sid);
-
-            if (data_written < 0) {
-               FTI_Print("sionlib: could not write data", FTI_EROR);
-               free(blBuf1);
-               fclose(lfd);
-               sion_parclose_mapped_mpi(FTI_Exec->sid);
-               return FTI_NSCS;
-            }
-
-            break;
-#endif
-      }
-
-      pos = pos + FTI_Conf->transferSize;
-
-   }
-
-   free(blBuf1);
-   fclose(lfd);
-   if (FTI_Conf->ioMode == FTI_IO_POSIX) {
-      fclose(gfd);
-   }
-
-   return FTI_SCES;
-}
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It selects I/O and prepares the flush for each I/O.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @param      level           The level from which ckpt. files are flushed.
-    @return     integer         FTI_SCES if successful.
-
-**/
-/*-------------------------------------------------------------------------*/
-int FTI_FlushInit(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
-{
-
-   int res;
-   if (level == -1) {
-      return FTI_SCES; // Fake call for inline PFS checkpoint
-   }
-
-   // create global temp directory
-   if (mkdir(FTI_Conf->gTmpDir, 0777) == -1) {
-      if (errno != EEXIST) {
-         FTI_Print("Cannot create global directory", FTI_EROR);
-         return FTI_NSCS;
-      }
-   }
-
-   // select IO
-   switch (FTI_Conf->ioMode) {
-
-      case FTI_IO_POSIX:
-
-         res = FTI_FlushInitPosix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
-         break;
-
-      case FTI_IO_MPI:
-
-         res = FTI_FlushInitMpi(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
-         break;
-
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-      case FTI_IO_SIONLIB:
-
-         // write checkpoint
-         res = FTI_FlushInitSionlib(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
-         break;
-#endif
-   }
-
-   return res;
-}
-
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It prepares the Flush for POSIX I/O.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @param      level           The level from which ckpt. files are flushed.
-    @return     integer         FTI_SCES if successful.
-
-    Initializes the flush of locally stored checkpoint data to the PFS by POSIX
-
-**/
-/*-------------------------------------------------------------------------*/
-int FTI_FlushInitPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-              FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
-{
-	unsigned long maxFs, fs;
-    int i, res;
-
-    if (FTI_Topo->amIaHead) {
-
-        for (i = 0; i<FTI_Topo->nbApprocs; i++) {
-
-            res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, i+1, level), "obtain metadata.");
-            if (res != FTI_SCES) {
-                FTI_Print("failed to obtain the metadata", FTI_EROR);
+                errno = 0;
+                int reslen;
+                char mpi_err[FTI_BUFS];
+                MPI_Error_string(res, mpi_err, &reslen);
+                snprintf(str, FTI_BUFS, "Failed to write data to PFS during MPIIO Flush [MPI ERROR - %i] %s", res, mpi_err);
+                FTI_Print(str, FTI_EROR);
+                free(localFileNames);
+                free(splitRanks);
+                free(allFileSizes);
+                fclose(lfd);
+                MPI_File_close(&pfh);
                 return FTI_NSCS;
             }
-            FTI_Exec->meta[i].fs = fs;
-            FTI_Exec->meta[i].maxFs = maxFs;
-            strcpy(FTI_Exec->meta[i].ckptFile, FTI_Exec->ckptFile);
+            MPI_Type_free(&dType);
+            offset += bytes;
+            pos = pos + bytes;
+        }
+        free(readData);
+        fclose(lfd);
+    }
+    free(localFileNames);
+    free(allFileSizes);
+    free(splitRanks);
+    MPI_File_close(&pfh);
+    return FTI_SCES;
+}
 
+/*-------------------------------------------------------------------------*/
+/**
+    @brief      It flushes the local ckpt. files in to the PFS using SIONlib.
+    @param      FTI_Conf        Configuration metadata.
+    @param      FTI_Exec        Execution metadata.
+    @param      FTI_Topo        Topology metadata.
+    @param      FTI_Ckpt        Checkpoint metadata.
+    @param      level           The level from which ckpt. files are flushed.
+    @return     integer         FTI_SCES if successful.
+
+    This function flushes the local checkpoint files in to the PFS.
+
+ **/
+/*-------------------------------------------------------------------------*/
+#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
+int FTI_FlushSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
+      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
+{
+    int proc, startProc, endProc;
+    if (FTI_Topo->amIaHead) {
+        startProc = 1;
+        endProc = FTI_Topo->nodeSize;
+    }
+    else {
+        startProc = 0;
+        endProc = 1;
+    }
+    int nbProc = endProc - startProc;
+
+    long* localFileSizes = talloc(long, nbProc);
+    char* localFileNames = talloc(char, FTI_BUFS * nbProc);
+    int* splitRanks = talloc(int, nbProc); //rank of process in FTI_COMM_WORLD
+    for (proc = startProc; proc < endProc; proc++) {
+        // Open local file case 0:
+        if (level == 0) {
+            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+        }
+        else {
+            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+        }
+        if (FTI_Topo->amIaHead) {
+            splitRanks[proc - startProc] = (FTI_Topo->nodeSize - 1) * FTI_Topo->nodeID + proc - 1; //[proc - startProc] to get index from 0
+        }
+        else {
+            splitRanks[proc - startProc] = FTI_Topo->splitRank; //[proc - startProc] to get index from 0
+        }
+        localFileSizes[proc - startProc] = FTI_Exec->meta[level].fs[proc]; //[proc - startProc] to get index from 0
+    }
+
+    int rank, ckptID;
+    char fn[FTI_BUFS], str[FTI_BUFS];
+    sscanf(&FTI_Exec->meta[level].ckptFile[0], "Ckpt%d-Rank%d.fti", &ckptID, &rank);
+    snprintf(str, FTI_BUFS, "Ckpt%d-sionlib.fti", ckptID);
+    sprintf(fn, "%s/%s", FTI_Conf->gTmpDir, str);
+
+    int numFiles = 1;
+    int nlocaltasks = nbProc;
+    int* file_map = calloc(nbProc, sizeof(int));
+    int* ranks = talloc(int, nbProc);
+    int* rank_map = talloc(int, nbProc);
+    sion_int64* chunkSizes = talloc(sion_int64, nbProc);
+    int fsblksize = -1;
+    int i;
+    for (i = 0; i < nbProc; i++) {
+        chunkSizes[i] = localFileSizes[i];
+        ranks[i] = splitRanks[i];
+        rank_map[i] = splitRanks[i];
+    }
+    int sid = sion_paropen_mapped_mpi(fn, "wb,posix", &numFiles, FTI_COMM_WORLD, &nlocaltasks, &ranks, &chunkSizes, &file_map, &rank_map, &fsblksize, NULL);
+    if (sid == -1) {
+       FTI_Print("Cannot open with sion_paropen_mapped_mpi.", FTI_EROR);
+
+       free(file_map);
+       free(ranks);
+       free(rank_map);
+       free(chunkSizes);
+
+       return FTI_NSCS;
+    }
+
+    for (proc = startProc; proc < endProc; proc++) {
+        FILE* lfd = fopen(&localFileNames[FTI_BUFS * proc], "rb");
+        if (lfd == NULL) {
+           FTI_Print("L4 cannot open the checkpoint file.", FTI_EROR);
+           free(localFileNames);
+           free(splitRanks);
+           sion_parclose_mapped_mpi(sid);
+           free(file_map);
+           free(ranks);
+           free(rank_map);
+           free(chunkSizes);
+           return FTI_NSCS;
         }
 
-    }
 
-    else {
-
-        res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, FTI_Topo->nodeRank, level), "obtain metadata.");
-        if (res != FTI_SCES)
-            return FTI_NSCS;
-
-        FTI_Exec->meta[0].fs = fs;
-        FTI_Exec->meta[0].maxFs = maxFs;
-        strcpy(FTI_Exec->meta[0].ckptFile, FTI_Exec->ckptFile);
-
-    }
-
-    return FTI_SCES;
-
-}
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It prepares the Flush for MPI I/O.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @param      level           The level from which ckpt. files are flushed.
-    @return     integer         FTI_SCES if successful.
-
-   Initializes the flush of locally stored checkpoint data to the PFS by MPI I/O
-
-**/
-/*-------------------------------------------------------------------------*/
-int FTI_FlushInitMpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
-{
-   char str[FTI_BUFS], mpi_err[FTI_BUFS];
-   unsigned long maxFs, fs;
-   int i, res, reslen;
-   MPI_Info info;
-
-   if (FTI_Topo->amIaHead) {
-
-      for (i = 0; i<FTI_Topo->nbApprocs; i++) {
-
-         res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, i+1, level), "obtain metadata.");
-         if (res != FTI_SCES) {
-            FTI_Print("failed to obtain the metadata", FTI_EROR);
-            return FTI_NSCS;
-         }
-         FTI_Exec->meta[i].fs = fs;
-         FTI_Exec->meta[i].maxFs = maxFs;
-         strcpy(FTI_Exec->meta[i].ckptFile, FTI_Exec->ckptFile);
-
-      }
-      // set parallel file name
-      snprintf(str, FTI_BUFS, "Ckpt%d-mpiio.fti", (FTI_Exec->ckptID+1));
-      sprintf(FTI_Exec->fn, "%s/%s", FTI_Conf->gTmpDir, str);
-
-
-   } else {
-
-      res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, FTI_Topo->nodeRank, level), "obtain metadata.");
-      if (res != FTI_SCES)
-         return FTI_NSCS;
-
-      FTI_Exec->meta[0].fs = fs;
-      FTI_Exec->meta[0].maxFs = maxFs;
-      strcpy(FTI_Exec->meta[0].ckptFile, FTI_Exec->ckptFile);
-
-      // set parallel file name
-      snprintf(str, FTI_BUFS, "Ckpt%d-mpiio.fti", (FTI_Exec->ckptID));
-      sprintf(FTI_Exec->fn, "%s/%s", FTI_Conf->gTmpDir, str);
-
-
-   }
-
-   // enable collective buffer optimization
-   MPI_Info_create(&info);
-   MPI_Info_set(info, "romio_cb_write", "enable");
-
-   // TODO enable to set stripping unit in the config file (Maybe also other hints)
-   // set stripping unit to 4MB
-   MPI_Info_set(info, "stripping_unit", "4194304");
-
-   // open parallel file (collective call)
-   res = MPI_File_open(FTI_COMM_WORLD, FTI_Exec->fn, MPI_MODE_WRONLY|MPI_MODE_CREATE, info, &(FTI_Exec->pfh));
-
-   // check if successful
-   if (res != 0) {
-      errno = 0;
-      MPI_Error_string(res, mpi_err, &reslen);
-      snprintf(str, FTI_BUFS, "unable to create file during flush initialization [MPI ERROR - %i] %s", res, mpi_err);
-      FTI_Print(str, FTI_EROR);
-      return FTI_NSCS;
-   }
-
-   MPI_Info_free(&info);
-   return FTI_SCES;
-
-}
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It prepares the Flush for SIONlib I/O.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @param      level           The level from which ckpt. files are flushed.
-    @return     integer         FTI_SCES if successful.
-
-   Initializes the flush of locally stored checkpoint data to the PFS by SIONlib
-
-**/
-/*-------------------------------------------------------------------------*/
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-int FTI_FlushInitSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
-{
-   unsigned long maxFs, fs;
-   int i, res, numFiles = 1, fsblksize = -1, nlocaltasks = 1;
-   sion_int64 *chunkSizes;
-   int *gRankList;
-   int *file_map;
-   int *rank_map;
-   char str[FTI_BUFS];
-   FILE *dfp;
-
-   if (FTI_Topo->amIaHead) {
-      gRankList = talloc(int, FTI_Topo->nbApprocs+1);
-      file_map = talloc(int, FTI_Topo->nbApprocs+1);
-      rank_map = talloc(int, FTI_Topo->nbApprocs+1);
-      chunkSizes = talloc(sion_int64, FTI_Topo->nbApprocs+1);
-      nlocaltasks = FTI_Topo->nbApprocs+1;
-      // gRankList has global ranks for which head is responsible.
-      // file_map maps file indices to ranks. we have only one file, so file index 0 for all ranks.
-      // rank_map has the ranks for the file mapping. indices are corresponding.
-      // SIONlib cant map if the writing rank is excluded. hence head rank is included with chunksize = 0.
-      gRankList[0] = FTI_Topo->myRank;
-      file_map[0]  = 0;
-      rank_map[0]  = gRankList[0];
-      chunkSizes[0] = 0;
-      for(i=1;i<FTI_Topo->nbApprocs+1;i++) {
-         gRankList[i] = FTI_Topo->body[i-1];
-         file_map[i]  = 0;
-         rank_map[i]  = gRankList[i];
-      }
-      // get metadata
-      for (i = 0; i<FTI_Topo->nbApprocs; i++) {
-         res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, i+1, level), "obtain metadata.");
-         if (res != FTI_SCES) {
-            FTI_Print("failed to obtain the metadata", FTI_EROR);
-
-            free(gRankList);
+        int res = sion_seek(sid, splitRanks[proc - startProc], SION_CURRENT_BLK, SION_CURRENT_POS);
+        if (res != SION_SUCCESS) {
+            errno = 0;
+            sprintf(str, "SIONlib: unable to set file pointer");
+            FTI_Print(str, FTI_EROR);
+            free(localFileNames);
+            free(splitRanks);
+            fclose(lfd);
+            sion_parclose_mapped_mpi(sid);
             free(file_map);
+            free(ranks);
             free(rank_map);
             free(chunkSizes);
-
             return FTI_NSCS;
-         }
-         FTI_Exec->meta[i].fs = fs;
-         FTI_Exec->meta[i].maxFs = maxFs;
-         strcpy(FTI_Exec->meta[i].ckptFile, FTI_Exec->ckptFile);
-         chunkSizes[i+1] = fs;
-      }
-      // set parallel file name
-      snprintf(str, FTI_BUFS, "Ckpt%d-sionlib.fti", (FTI_Exec->ckptID+1));
-      sprintf(FTI_Exec->fn, "%s/%s", FTI_Conf->gTmpDir, str);
+        }
 
-      // open parallel file in collective call for all heads
-      FTI_Exec->sid = sion_paropen_mapped_mpi(FTI_Exec->fn, "wb,posix", &numFiles, FTI_COMM_WORLD, &nlocaltasks, &gRankList, &chunkSizes, &file_map, &rank_map, &fsblksize, &dfp);
-      if (FTI_Exec->sid == -1) {
-         FTI_Print("PAROPEN MAPPED ERROR", FTI_EROR);
+        char *readData = talloc(char, FTI_Conf->transferSize);
+        long bSize = FTI_Conf->transferSize;
+        long fs = FTI_Exec->meta[level].fs[proc];
 
-         free(gRankList);
-         free(file_map);
-         free(rank_map);
-         free(chunkSizes);
+        long pos = 0;
+        // Checkpoint files exchange
+        while (pos < fs) {
+            if ((fs - pos) < FTI_Conf->transferSize)
+                bSize = fs - pos;
 
-         return FTI_NSCS;
-      }
-   }
+            size_t bytes = fread(readData, sizeof(char), bSize, lfd);
+            if (ferror(lfd)) {
+                FTI_Print("L4 cannot read from the ckpt. file.", FTI_EROR);
+                free(localFileNames);
+                free(splitRanks);
+                free(readData);
+                fclose(lfd);
+                sion_parclose_mapped_mpi(sid);
+                free(file_map);
+                free(ranks);
+                free(rank_map);
+                free(chunkSizes);
+                return FTI_NSCS;
+            }
 
-   else {
-      // set parallel file name
-      snprintf(str, FTI_BUFS, "Ckpt%d-sionlib.fti", FTI_Exec->ckptID);
-      sprintf(FTI_Exec->fn, "%s/%s", FTI_Conf->gTmpDir, str);
+            long data_written = sion_fwrite(readData, sizeof(char), bytes, sid);
 
-      res = FTI_Try(FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, FTI_Topo->nodeRank, level), "obtain metadata.");
-      if (res != FTI_SCES)
-         return FTI_NSCS;
+            if (data_written < 0) {
+                FTI_Print("Sionlib: could not write data", FTI_EROR);
+                free(localFileNames);
+                free(splitRanks);
+                free(readData);
+                fclose(lfd);
+                sion_parclose_mapped_mpi(sid);
+                free(file_map);
+                free(ranks);
+                free(rank_map);
+                free(chunkSizes);
+                return FTI_NSCS;
+            }
 
-      // set parameter for paropen mapped call
-      if (FTI_Topo->nbHeads == 1 && FTI_Topo->groupID == 1) {
-
-         // for the case that we have a head
-         nlocaltasks = 2;
-         gRankList = talloc(int, 2);
-         chunkSizes = talloc(sion_int64, 2);
-         file_map = talloc(int, 2);
-         rank_map = talloc(int, 2);
-
-         chunkSizes[0] = 0;
-         chunkSizes[1] = fs;
-         gRankList[0] = FTI_Topo->headRank;
-         gRankList[1] = FTI_Topo->myRank;
-         file_map[0] = 0;
-         file_map[1] = 0;
-         rank_map[0] = gRankList[0];
-         rank_map[1] = gRankList[1];
-
-      } else {
-
-         nlocaltasks = 1;
-         gRankList = talloc(int, 1);
-         chunkSizes = talloc(sion_int64, 1);
-         file_map = talloc(int, 1);
-         rank_map = talloc(int, 1);
-
-         *chunkSizes = fs;
-         *gRankList = FTI_Topo->myRank;
-         *file_map = 0;
-         *rank_map = *gRankList;
-
-      }
-
-      FTI_Exec->meta[0].fs = fs;
-      FTI_Exec->meta[0].maxFs = maxFs;
-      strcpy(FTI_Exec->meta[0].ckptFile, FTI_Exec->ckptFile);
-
-      FTI_Exec->sid = sion_paropen_mapped_mpi(FTI_Exec->fn, "wb,posix", &numFiles, FTI_COMM_WORLD, &nlocaltasks, &gRankList, &chunkSizes, &file_map, &rank_map, &fsblksize, NULL);
-      if (FTI_Exec->sid == -1) {
-         FTI_Print("PAROPEN MAPPED ERROR", FTI_EROR);
-
-         free(gRankList);
-         free(file_map);
-         free(rank_map);
-         free(chunkSizes);
-
-         return FTI_NSCS;
-      }
-   }
-
-   free(gRankList);
-   free(file_map);
-   free(rank_map);
-   free(chunkSizes);
-
-   return FTI_SCES;
+            pos = pos + bytes;
+        }
+    }
+    free(localFileNames);
+    free(splitRanks);
+    sion_parclose_mapped_mpi(sid);
+    free(file_map);
+    free(ranks);
+    free(rank_map);
+    free(chunkSizes);
 }
 #endif
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It selects I/O and Finalizes Flush respectively.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @param      level           The level from which ckpt. files are flushed.
-    @return     integer         FTI_SCES if successful.
-
-**/
-/*-------------------------------------------------------------------------*/
-int FTI_FlushFinalize(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
-{
-   int res;
-
-   if (level == -1 ) {
-      return FTI_SCES; // Fake call for inline PFS checkpoint
-   }
-
-   // select IO
-   switch(FTI_Conf->ioMode) {
-
-      case FTI_IO_POSIX:
-
-         res = FTI_SCES;
-         break;
-
-      case FTI_IO_MPI:
-
-         res = FTI_FlushFinalizeMpi(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
-         break;
-
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-      case FTI_IO_SIONLIB:
-
-         res = FTI_FlushFinalizeSionlib(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
-         break;
-#endif
-   }
-
-   return res;
-
-}
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It finalizes flush for SIONlib I/O.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @return     integer         FTI_SCES if successful.
-
-**/
-/*-------------------------------------------------------------------------*/
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-int FTI_FlushFinalizeSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
-{
-
-   int res, i;
-
-   sion_parclose_mapped_mpi(FTI_Exec->sid);
-
-   if (FTI_Topo->amIaHead) {
-
-      // set parallel file name
-      snprintf(FTI_Exec->ckptFile, FTI_BUFS, "Ckpt%d-sionlib.fti", FTI_Exec->ckptID+1);
-
-      // update meta data
-      for (i = 0; i < FTI_Topo->nbApprocs; i++) {
-         res = FTI_Try(FTI_CreateMetadata(FTI_Conf, FTI_Exec, FTI_Topo, 1, i), "create metadata.");
-         if (res != FTI_SCES) {
-            return FTI_NSCS;
-         }
-      }
-   }
-
-   else {
-
-      // set parallel file name
-      snprintf(FTI_Exec->ckptFile, FTI_BUFS, "Ckpt%d-sionlib.fti", FTI_Exec->ckptID);
-      res = FTI_Try(FTI_CreateMetadata(FTI_Conf, FTI_Exec, FTI_Topo, 1, 0), "create metadata.");
-      if (res != FTI_SCES) {
-         return FTI_NSCS;
-      }
-
-   }
-   return FTI_SCES;
-
-}
-#endif
-
-/*-------------------------------------------------------------------------*/
-/**
-    @brief      It finalizes flush for MPI I/O.
-    @param      FTI_Conf        Configuration metadata.
-    @param      FTI_Exec        Execution metadata.
-    @param      FTI_Topo        Topology metadata.
-    @param      FTI_Ckpt        Checkpoint metadata.
-    @return     integer         FTI_SCES if successful.
-
-**/
-/*-------------------------------------------------------------------------*/
-int FTI_FlushFinalizeMpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-      FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
-{
-
-   int res, i;
-
-   MPI_File_close(&(FTI_Exec->pfh));
-
-   if (FTI_Topo->amIaHead) {
-
-      // set parallel file name
-      snprintf(FTI_Exec->ckptFile, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID+1);
-
-      // update meta data
-      for (i = 0; i < FTI_Topo->nbApprocs; i++) {
-         res = FTI_Try(FTI_CreateMetadata(FTI_Conf, FTI_Exec, FTI_Topo, 1, i), "create metadata.");
-         if (res != FTI_SCES) {
-            return FTI_NSCS;
-         }
-      }
-   }
-
-   else {
-
-      // set parallel file name
-      snprintf(FTI_Exec->ckptFile, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
-      res = FTI_Try(FTI_CreateMetadata(FTI_Conf, FTI_Exec, FTI_Topo, 1, 0), "create metadata.");
-      if (res != FTI_SCES) {
-         return FTI_NSCS;
-      }
-
-   }
-   return FTI_SCES;
-}

--- a/src/postreco.c
+++ b/src/postreco.c
@@ -14,8 +14,6 @@
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      fs              The ckpt. file size for this process.
-    @param      maxFs           The max. ckpt. file size in the group.
     @param      erased          The array of erasures.
     @return     integer         FTI_SCES if successful.
 
@@ -25,12 +23,13 @@
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_Decode(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-               FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
-               int fs, int maxFs, int* erased)
+               FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int* erased)
 {
     int *matrix, *decMatrix, *dm_ids, *tmpmat, i, j, k, m, ps, bs, pos = 0;
     char **coding, **data, *dataTmp, fn[FTI_BUFS], efn[FTI_BUFS];
     FILE *fd, *efd;
+    long fs = FTI_Exec->meta[3].fs[0];
+    long maxFs = FTI_Exec->meta[3].maxFs[0];
 
     bs = FTI_Conf->blockSize;
     k = FTI_Topo->groupSize;
@@ -46,9 +45,10 @@ int FTI_Decode(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         }
     }
 
-    sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &i);
-    sprintf(fn, "%s/%s", FTI_Ckpt[3].dir, FTI_Exec->ckptFile);
-    sprintf(efn, "%s/Ckpt%d-RSed%d.fti", FTI_Ckpt[3].dir, FTI_Exec->ckptID, i);
+    int ckptID, rank;
+    sscanf(FTI_Exec->meta[3].ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank);
+    sprintf(efn, "%s/Ckpt%d-RSed%d.fti", FTI_Ckpt[3].dir, ckptID, rank);
+    sprintf(fn, "%s/%s", FTI_Ckpt[3].dir, FTI_Exec->meta[3].ckptFile);
 
     data = talloc(char*, k);
     coding = talloc(char*, m);
@@ -312,7 +312,6 @@ int FTI_Decode(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      group           The group ID.
     @return     integer         FTI_SCES if successful.
 
     This function detects all the erasures for L1. If there is at least one,
@@ -321,11 +320,11 @@ int FTI_Decode(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecoverL1(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
     int erased[FTI_BUFS], buf, j; // FTI_BUFS > 32*3
     unsigned long fs, maxFs;
-    if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, erased, 1) != FTI_SCES) {
+    if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, erased) != FTI_SCES) {
         FTI_Print("Error checking erasures.", FTI_DBUG);
         return FTI_NSCS;
     }
@@ -348,10 +347,8 @@ int FTI_RecoverL1(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     @param      FTI_Conf        Configuration metadata.
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      destination     destination group rank
-    @param      fs              Filesize.
+    @param      destination     destination group rank.
     @param      ptner           0 if sending Ckpt, 1 if PtnerCkpt.
-
     @return     integer         FTI_SCES if successful.
 
     This function sends Ckpt or PtnerCkpt file from partner proccess.
@@ -359,17 +356,19 @@ int FTI_RecoverL1(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_SendCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                        FTIT_checkpoint* FTI_Ckpt, int destination,
-                         unsigned long fs, int ptner) {
+                        FTIT_checkpoint* FTI_Ckpt, int destination, int ptner) {
     char filename[FTI_BUFS], str[FTI_BUFS];
     FILE *fileDesc;
 
+    long toSend ; // remaining data to send
     if (ptner) {    //if want to send Ptner file
-        int rank;
-        sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &rank); //do we need this from filename?
-        sprintf(filename, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, FTI_Exec->ckptID, rank);
+        int ckptID, rank;
+        sscanf(FTI_Exec->meta[2].ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank); //do we need this from filename?
+        sprintf(filename, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, ckptID, rank);
+        toSend = FTI_Exec->meta[2].pfs[0];
     } else {    //if want to send Ckpt file
-        sprintf(filename, "%s/%s", FTI_Ckpt[2].dir, FTI_Exec->ckptFile);
+        sprintf(filename, "%s/%s", FTI_Ckpt[2].dir, FTI_Exec->meta[2].ckptFile);
+        toSend = FTI_Exec->meta[2].fs[0];
     }
 
     sprintf(str, "Opening file (rb) (%s) (L2).", filename);
@@ -380,7 +379,7 @@ int FTI_SendCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         return FTI_NSCS;
     }
     char* buffer = talloc(char, FTI_Conf->blockSize);
-    unsigned long toSend = fs; // remaining data to send
+
     while (toSend > 0) {
         int sendSize = (toSend > FTI_Conf->blockSize) ? FTI_Conf->blockSize : toSend;
         size_t bytes = fread(buffer, sizeof(char), sendSize, fileDesc);
@@ -411,7 +410,6 @@ int FTI_SendCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
     @param      source          Source group rank.
-    @param      fs              Filesize.
     @param      ptner           0 if receiving Ckpt, 1 if PtnerCkpt.
     @return     integer         FTI_SCES if successful.
 
@@ -420,17 +418,19 @@ int FTI_SendCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecvCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                        FTIT_checkpoint* FTI_Ckpt, int source, unsigned long fs,
-                         int ptner) {
+                        FTIT_checkpoint* FTI_Ckpt, int source, int ptner) {
     char filename[FTI_BUFS], str[FTI_BUFS];
     FILE *fileDesc;
 
+    long toRecv;    //remaining data to receive
     if (ptner) { //if want to receive Ptner file
-        int rank;
-        sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &rank); //do we need this from filename?
+        int ckptID, rank;
+        sscanf(FTI_Exec->meta[2].ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank);
         sprintf(filename, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, FTI_Exec->ckptID, rank);
+        toRecv = FTI_Exec->meta[2].pfs[0];
     } else { //if want to receive Ckpt file
-        sprintf(filename, "%s/%s", FTI_Ckpt[2].dir, FTI_Exec->ckptFile);
+        sprintf(filename, "%s/%s", FTI_Ckpt[2].dir, FTI_Exec->meta[2].ckptFile);
+        toRecv = FTI_Exec->meta[2].fs[0];
     }
 
     sprintf(str, "Opening file (wb) (%s) (L2).", filename);
@@ -441,7 +441,7 @@ int FTI_RecvCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         return FTI_NSCS;
     }
     char* buffer = talloc(char, FTI_Conf->blockSize);
-    int toRecv = fs;    //remaining data to receive
+
     while (toRecv > 0) {
         int recvSize = (toRecv > FTI_Conf->blockSize) ? FTI_Conf->blockSize : toRecv;
         MPI_Recv(buffer, recvSize, MPI_CHAR, source, FTI_Conf->tag, FTI_Exec->groupComm, MPI_STATUS_IGNORE);
@@ -472,7 +472,6 @@ int FTI_RecvCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      group           The group ID.
     @return     integer         FTI_SCES if successful.
 
     This function tries to recover the L2 ckpt. files missing using the
@@ -482,10 +481,9 @@ int FTI_RecvCkptFileL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
     int erased[FTI_BUFS];
-    unsigned long fs, maxFs; //fileSize, maxFileSize
     int i, j; //iterators
     int source = FTI_Topo->right; //to receive Ptner file from this process (to recover)
     int destination = FTI_Topo->left; //to send Ptner file (to let him recover)
@@ -498,7 +496,7 @@ int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     }
 
     // Checking erasures
-    if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, erased, 2) != FTI_SCES) {
+    if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, erased) != FTI_SCES) {
         FTI_Print("Error checking erasures.", FTI_WARN);
         return FTI_NSCS;
     }
@@ -528,43 +526,33 @@ int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     MPI_Allreduce(&res, &tres, 1, MPI_INT, MPI_SUM, FTI_Exec->groupComm);
     if (tres != FTI_SCES) {
-        return FTI_NSCS; //needed FTI_Abort?
+        return FTI_NSCS;
     }
 
     //recover checkpoint files
     if (FTI_Topo->groupRank % 2) {
         if (erased[destination]) { //first send file
-            unsigned long pfs; //Ptner file size
-            res = FTI_GetPtnerSize(FTI_Conf, FTI_Topo, FTI_Ckpt, &pfs, group, 2);
-            if (res == FTI_NSCS) {
-                return FTI_NSCS;
-            }
-            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, pfs, 1);
+            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, 1);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
         }
         if (erased[FTI_Topo->groupRank]) { //then receive file
-            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, fs, 0);
+            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, 0);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
         }
     } else {
         if (erased[FTI_Topo->groupRank]) { //first receive file
-            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, fs, 0);
+            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, 0);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
         }
 
         if (erased[destination]) { //then send file
-            unsigned long pfs; //Ptner file size
-            res = FTI_GetPtnerSize(FTI_Conf, FTI_Topo, FTI_Ckpt, &pfs, group, 2);
-            if (res == FTI_NSCS) {
-                return FTI_NSCS;
-            }
-            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, pfs, 1);
+            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, 1);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
@@ -574,37 +562,27 @@ int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     //recover partner files
     if (FTI_Topo->groupRank % 2) {
         if (erased[source + FTI_Topo->groupSize]) { //fisrst send file
-            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, fs, 0);
+            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, 0);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
         }
         if (erased[FTI_Topo->groupRank + FTI_Topo->groupSize]) { //receive file
-            unsigned long pfs; //Ptner file size
-            res = FTI_GetPtnerSize(FTI_Conf, FTI_Topo, FTI_Ckpt, &pfs, group, 2);
-            if (res == FTI_NSCS) {
-                return FTI_NSCS;
-            }
-            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, pfs, 1);
+            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, 1);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
         }
     } else {
         if (erased[FTI_Topo->groupRank + FTI_Topo->groupSize]) { //first receive file
-            unsigned long pfs; //Ptner file size
-            res = FTI_GetPtnerSize(FTI_Conf, FTI_Topo, FTI_Ckpt, &pfs, group, 2);
-            if (res == FTI_NSCS) {
-                return FTI_NSCS;
-            }
-            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, pfs, 1);
+            res = FTI_RecvCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, destination, 1);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
         }
 
         if (erased[source + FTI_Topo->groupSize]) { //send file
-            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, fs, 0);
+            res = FTI_SendCkptFileL2(FTI_Conf, FTI_Exec, FTI_Ckpt, source, 0);
             if (res != FTI_SCES) {
                 return FTI_NSCS;
             }
@@ -621,7 +599,6 @@ int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      group           The group ID.
     @return     integer         FTI_SCES if successful.
 
     This function tries to recover the L3 ckpt. files missing using the
@@ -631,12 +608,11 @@ int FTI_RecoverL2(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-    int erased[FTI_BUFS], gs, j, l = 0;
-    unsigned long fs, maxFs;
+    int erased[FTI_BUFS], j;
     char str[FTI_BUFS];
-    gs = FTI_Topo->groupSize;
+
 
     if (mkdir(FTI_Ckpt[3].dir, 0777) == -1) {
         if (errno != EEXIST) {
@@ -645,13 +621,14 @@ int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     }
 
     // Checking erasures
-    if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, erased, 3) != FTI_SCES) {
+    if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, erased) != FTI_SCES) {
         FTI_Print("Error checking erasures.", FTI_DBUG);
         return FTI_NSCS;
     }
 
     // Counting erasures
-    l = 0;
+    int l = 0;
+    int gs = FTI_Topo->groupSize;
     for (j = 0; j < gs; j++) {
         if (erased[j]) {
             l++;
@@ -669,7 +646,7 @@ int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     if (l > 0) {
         sprintf(str, "There are %d encoded/checkpoint files missing in this group.", l);
         FTI_Print(str, FTI_DBUG);
-        if (FTI_Decode(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, fs, maxFs, erased) == FTI_NSCS) {
+        if (FTI_Decode(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, erased) == FTI_NSCS) {
             FTI_Print("RS-decoding could not regenerate the missing data.", FTI_DBUG);
             return FTI_NSCS;
         }
@@ -685,7 +662,6 @@ int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      group           The group ID.
     @return     integer         FTI_SCES if successful.
 
     This function tries to recover the ckpt. files using the L4 ckpt. files
@@ -695,21 +671,23 @@ int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecoverL4(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
    int res;
-   switch(FTI_Conf->ioMode) {
-      case FTI_IO_POSIX:
-         res = FTI_RecoverL4Posix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, group);
-         break;
-      case FTI_IO_MPI:
-         res = FTI_RecoverL4Mpi(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
-         break;
+   if (!FTI_Ckpt[4].isInline || FTI_Conf->ioMode == FTI_IO_POSIX) {
+       res = FTI_RecoverL4Posix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+   }
+   else {
+       switch(FTI_Conf->ioMode) {
+          case FTI_IO_MPI:
+             res = FTI_RecoverL4Mpi(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+             break;
 #ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-      case FTI_IO_SIONLIB:
-         res = FTI_RecoverL4Sionlib(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
-         break;
+          case FTI_IO_SIONLIB:
+             res = FTI_RecoverL4Sionlib(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+             break;
 #endif
+       }
    }
 
    return res;
@@ -718,7 +696,6 @@ int FTI_RecoverL4(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 /*-------------------------------------------------------------------------*/
 /**
     @brief      It recovers L4 ckpt. files from the PFS using POSIX.
-    @param      group           The group ID.
     @param      FTI_Conf        Configuration metadata.
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
@@ -732,9 +709,8 @@ int FTI_RecoverL4(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int group)
+                  FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-   unsigned long maxFs, fs, ps, pos = 0;
    int j, l, gs, erased[FTI_BUFS];
    char gfn[FTI_BUFS], lfn[FTI_BUFS];
    FILE *gfd, *lfd;
@@ -748,7 +724,7 @@ int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
    }
    MPI_Barrier(FTI_COMM_WORLD);
    // Checking erasures
-   if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, group, erased, 4) != FTI_SCES) {
+   if (FTI_CheckErasures(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, erased) != FTI_SCES) {
       FTI_Print("Error checking erasures.", FTI_DBUG);
       return FTI_NSCS;
    }
@@ -764,41 +740,40 @@ int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
       return FTI_NSCS;
    }
 
-   ps = (fs / FTI_Conf->blockSize) * FTI_Conf->blockSize;
-   pos = 0; // For the logic
-   // Calculating padding size
-   if (ps < fs)
-      ps = ps + FTI_Conf->blockSize;
-   // Open and resize files
-   sprintf(gfn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->ckptFile);
-   sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->ckptFile);
-
-   if (truncate(gfn, ps) == -1) {
-      FTI_Print("R4 cannot truncate the ckpt. file in the PFS.", FTI_DBUG);
-      return FTI_NSCS;
-   }
+   // Open files
+   sprintf(FTI_Exec->meta[1].ckptFile, "Ckpt%d-Rank%d.fti", FTI_Exec->ckptID, FTI_Topo->myRank);
+   sprintf(FTI_Exec->meta[4].ckptFile, "Ckpt%d-Rank%d.fti", FTI_Exec->ckptID, FTI_Topo->myRank);
+   sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->meta[1].ckptFile);
+   sprintf(gfn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->meta[4].ckptFile);
 
    gfd = fopen(gfn, "rb");
    if (gfd == NULL) {
-      FTI_Print("R4 cannot open the ckpt. file in the PFS.", FTI_DBUG);
+      FTI_Print("R4 cannot open the ckpt. file in the PFS.", FTI_WARN);
       return FTI_NSCS;
    }
 
    lfd = fopen(lfn, "wb");
    if (lfd == NULL) {
-      FTI_Print("R4 cannot open the local ckpt. file.", FTI_DBUG);
+      FTI_Print("R4 cannot open the local ckpt. file.", FTI_WARN);
       fclose(gfd);
       return FTI_NSCS;
    }
 
-   char *blBuf1 = talloc(char, FTI_Conf->blockSize);
+   char *readData = talloc(char, FTI_Conf->transferSize);
+   long bSize = FTI_Conf->transferSize;
+   long fs = FTI_Exec->meta[4].fs[0];
    // Checkpoint files transfer from PFS
-   while (pos < ps) {
-      size_t bytes = fread(blBuf1, sizeof(char), FTI_Conf->blockSize, gfd);
+   long pos = 0;
+   while (pos < fs) {
+      if ((fs - pos) < FTI_Conf->transferSize) {
+         bSize = fs - pos;
+      }
+
+      size_t bytes = fread(readData, sizeof(char), bSize, gfd);
       if (ferror(gfd)) {
          FTI_Print("R4 cannot read from the ckpt. file in the PFS.", FTI_DBUG);
 
-         free(blBuf1);
+         free(readData);
 
          fclose(gfd);
          fclose(lfd);
@@ -806,11 +781,11 @@ int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
          return  FTI_NSCS;
       }
 
-      fwrite(blBuf1, sizeof(char), bytes, lfd);
+      fwrite(readData, sizeof(char), bytes, lfd);
       if (ferror(lfd)) {
          FTI_Print("R4 cannot write to the local ckpt. file.", FTI_DBUG);
 
-         free(blBuf1);
+         free(readData);
 
          fclose(gfd);
          fclose(lfd);
@@ -818,22 +793,13 @@ int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
          return  FTI_NSCS;
       }
 
-      pos = pos + FTI_Conf->blockSize;
+      pos = pos + bytes;
    }
 
-   free(blBuf1);
+   free(readData);
 
    fclose(gfd);
    fclose(lfd);
-
-   if (truncate(gfn, fs) == -1) {
-      FTI_Print("R4 cannot re-truncate the checkpoint file in the PFS.", FTI_DBUG);
-      return FTI_NSCS;
-   }
-   if (truncate(lfn, fs) == -1) {
-      FTI_Print("R4 cannot re-truncate the local checkpoint file.", FTI_DBUG);
-      return FTI_NSCS;
-   }
 
    return FTI_SCES;
 }
@@ -856,136 +822,105 @@ int FTI_RecoverL4Posix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
       FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-   int i, reslen, buf;
+   int i, buf;
    char gfn[FTI_BUFS], lfn[FTI_BUFS], mpi_err[FTI_BUFS], str[FTI_BUFS];
-   FILE *lfd;
-   MPI_File pfh;
-   MPI_Offset offset = 0, nbBlocks, block = 0, lastBlockBytes, *chunkSizes;
-   MPI_Status status;
-   MPI_Info info;
 
    // TODO enable to set stripping unit in the config file (Maybe also other hints)
    // enable collective buffer optimization
+   MPI_Info info;
    MPI_Info_create(&info);
    MPI_Info_set(info, "romio_cb_read", "enable");
 
    // set stripping unit to 4MB
    MPI_Info_set(info, "stripping_unit", "4194304");
 
-   sprintf(gfn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->ckptFile);
-
-   // rename checkpoint file.
-   sprintf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", FTI_Exec->ckptID, FTI_Topo->myRank);
-   sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->ckptFile);
+   sprintf(FTI_Exec->meta[1].ckptFile, "Ckpt%d-Rank%d.fti", FTI_Exec->ckptID, FTI_Topo->myRank);
+   sprintf(FTI_Exec->meta[4].ckptFile, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
+   sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->meta[1].ckptFile);
+   sprintf(gfn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->meta[4].ckptFile);
 
    // open parallel file
+   MPI_File pfh;
    buf = MPI_File_open(FTI_COMM_WORLD, gfn, MPI_MODE_RDWR, info, &pfh);
    // check if successful
    if (buf != 0) {
       errno = 0;
-      MPI_Error_string(buf, mpi_err, &reslen);
+      MPI_Error_string(buf, mpi_err, NULL);
       if (buf != MPI_ERR_NO_SUCH_FILE) {
-         snprintf(str, FTI_BUFS, "unable to access file [MPI ERROR - %i] %s", buf, mpi_err);
+         snprintf(str, FTI_BUFS, "Unable to access file [MPI ERROR - %i] %s", buf, mpi_err);
          FTI_Print(str, FTI_EROR);
       }
       return FTI_NSCS;
    }
 
    // create local directories
-   if (FTI_Topo->nodeRank == 0 || FTI_Topo->nodeRank == 1) {
-      if (mkdir(FTI_Ckpt[1].dir, 0777) == -1) {
-         if (errno != EEXIST)
-            FTI_Print("Directory L1 could NOT be created.", FTI_WARN);
+   if (mkdir(FTI_Ckpt[1].dir, 0777) == -1) {
+      if (errno != EEXIST) {
+          FTI_Print("Directory L1 could NOT be created.", FTI_WARN);
       }
    }
-   MPI_Barrier(FTI_COMM_WORLD);
 
    // collect chunksizes of other ranks
-   chunkSizes = talloc(MPI_Offset, FTI_Topo->nbApprocs*FTI_Topo->nbNodes);
-   MPI_Allgather(&(FTI_Exec->meta[0].fs), 1, MPI_OFFSET, chunkSizes, 1, MPI_OFFSET, FTI_COMM_WORLD);
+   MPI_Offset* chunkSizes = talloc(MPI_Offset, FTI_Topo->nbApprocs*FTI_Topo->nbNodes);
+   MPI_Allgather(FTI_Exec->meta[4].fs, 1, MPI_OFFSET, chunkSizes, 1, MPI_OFFSET, FTI_COMM_WORLD);
 
+   MPI_Offset offset = 0;
    // set file offset
-   for (i=0; i<FTI_Topo->splitRank; i++) {
+   for (i = 0; i < FTI_Topo->splitRank; i++) {
       offset += chunkSizes[i];
    }
    free(chunkSizes);
-   // number of blocks
-   nbBlocks = (FTI_Exec->meta[0].fs) / FTI_Conf->transferSize;
-   block = 0; // For the logic
-   lastBlockBytes = (FTI_Exec->meta[0].fs) % FTI_Conf->transferSize; // modulo for size of last block in bytes
 
-   lfd = fopen(lfn, "wb");
+   FILE *lfd = fopen(lfn, "wb");
    if (lfd == NULL) {
       FTI_Print("R4 cannot open the local ckpt. file.", FTI_DBUG);
       MPI_File_close(&pfh);
       return FTI_NSCS;
    }
 
-   char *blBuf1 = talloc(char, FTI_Conf->transferSize);
-
+   long fs = FTI_Exec->meta[4].fs[0];
+   char *readData = talloc(char, FTI_Conf->transferSize);
+   long bSize = FTI_Conf->transferSize;
+   long pos = 0;
    // Checkpoint files transfer from PFS
-   while (block < nbBlocks) {
-
+   while (pos < fs) {
+       if ((fs - pos) < FTI_Conf->transferSize) {
+           bSize = fs - pos;
+       }
       // read block in parallel file
-      buf = MPI_File_read_at(pfh, offset, blBuf1, FTI_Conf->transferSize, MPI_BYTE, &status);
+      buf = MPI_File_read_at(pfh, offset, readData, bSize, MPI_BYTE, MPI_STATUS_IGNORE);
       // check if successful
       if (buf != 0) {
          errno = 0;
-         MPI_Error_string(buf, mpi_err, &reslen);
+         MPI_Error_string(buf, mpi_err, NULL);
          snprintf(str, FTI_BUFS, "R4 cannot read from the ckpt. file in the PFS. [MPI ERROR - %i] %s", buf, mpi_err);
          FTI_Print(str, FTI_EROR);
+         free(readData);
          MPI_File_close(&pfh);
-         free(blBuf1);
          fclose(lfd);
          return FTI_NSCS;
       }
 
-      fwrite(blBuf1, sizeof(char), FTI_Conf->transferSize, lfd);
+      fwrite(readData, sizeof(char), bSize, lfd);
       if (ferror(lfd)) {
          FTI_Print("R4 cannot write to the local ckpt. file.", FTI_DBUG);
-         free(blBuf1);
+         free(readData);
          fclose(lfd);
          MPI_File_close(&pfh);
          return  FTI_NSCS;
       }
 
-      offset += FTI_Conf->transferSize;
-      block++;
+      offset += bSize;
+      pos = pos + bSize;
    }
 
-   // read block in parallel file
-   buf = MPI_File_read_at(pfh, offset, blBuf1, lastBlockBytes, MPI_BYTE, &status);
-   // check if successful
-   if (buf != 0) {
-      errno = 0;
-      MPI_Error_string(buf, mpi_err, &reslen);
-      snprintf(str, FTI_BUFS, "R4 cannot read from the ckpt. file in the PFS. [MPI ERROR - %i] %s", buf, mpi_err);
-      FTI_Print(str, FTI_EROR);
-      MPI_File_close(&pfh);
-      fclose(lfd);
-      free(blBuf1);
-      return FTI_NSCS;
-   }
-
-   fwrite(blBuf1, sizeof(char), lastBlockBytes, lfd);
-   if (ferror(lfd)) {
-      FTI_Print("R4 cannot write to the local ckpt. file.", FTI_DBUG);
-      free(blBuf1);
-      fclose(lfd);
-      MPI_File_close(&pfh);
-      return  FTI_NSCS;
-   }
-
-
-   free(blBuf1);
+   free(readData);
+   fclose(lfd);
 
    if (MPI_File_close(&pfh) != 0) {
-      fclose(lfd);
-
+      FTI_Print("Cannot close MPI file.", FTI_WARN);
       return FTI_NSCS;
    }
-
-   fclose(lfd);
 
    return FTI_SCES;
 }
@@ -1009,154 +944,111 @@ int FTI_RecoverL4Mpi(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_RecoverL4Sionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
       FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-   size_t nbBlocks, block = 0, lastBlockBytes;
-   int sid, nlocaltasks = 1, numFiles = 1, res;
-   int *gRankList, *file_map, *rank_map;
+   int res;
    char str[FTI_BUFS], gfn[FTI_BUFS], lfn[FTI_BUFS];
-   FILE *lfd, *dfp;
-   sion_int64 *chunkSizes, chunksize;
-   sion_int32 fsblksize=-1;
 
-   if (FTI_Topo->nodeRank == 0 || FTI_Topo->nodeRank == 1) {
-      if (mkdir(FTI_Ckpt[1].dir, 0777) == -1) {
-         if (errno != EEXIST) {
-            FTI_Print("Directory L1 could NOT be created.", FTI_WARN);
-         }
-      }
+   if (mkdir(FTI_Ckpt[1].dir, 0777) == -1) {
+       if (errno != EEXIST) {
+           FTI_Print("Directory L1 could NOT be created.", FTI_WARN);
+       }
    }
 
-   MPI_Barrier(FTI_COMM_WORLD);
-
-   sprintf(gfn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->ckptFile);
-
-   sprintf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", FTI_Exec->ckptID, FTI_Topo->myRank);
-   sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->ckptFile);
+   sprintf(FTI_Exec->meta[1].ckptFile, "Ckpt%d-Rank%d.fti", FTI_Exec->ckptID, FTI_Topo->myRank);
+   sprintf(FTI_Exec->meta[4].ckptFile, "Ckpt%d-sionlib.fti", FTI_Exec->ckptID);
+   sprintf(lfn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->meta[1].ckptFile);
+   sprintf(gfn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->meta[4].ckptFile);
 
    // this is done, since sionlib aborts if the file is not readable.
    if (access(gfn, F_OK) != 0) {
       return FTI_NSCS;
    }
 
-   // set parameter for paropen mapped call
-   if (FTI_Topo->nbHeads == 1 && FTI_Topo->groupID == 1) {
+   int numFiles = 1;
+   int nlocaltasks = 1;
+   int* file_map = calloc(1, sizeof(int));
+   int* ranks = talloc(int, 1);
+   int* rank_map = talloc(int, 1);
+   sion_int64* chunkSizes = talloc(sion_int64, 1);
+   int fsblksize = -1;
+   chunkSizes[0] = FTI_Exec->meta[4].fs[0];
+   ranks[0] = FTI_Topo->splitRank;
+   rank_map[0] = FTI_Topo->splitRank;
+   int sid = sion_paropen_mapped_mpi(gfn, "rb,posix", &numFiles, FTI_COMM_WORLD, &nlocaltasks, &ranks, &chunkSizes, &file_map, &rank_map, &fsblksize, NULL);
 
-      // for the case that we have a head
-      nlocaltasks = 2;
-      gRankList = talloc(int, 2);
-      chunkSizes = talloc(sion_int64, 2);
-      file_map = talloc(int, 2);
-      rank_map = talloc(int, 2);
-
-      //        chunkSizes[0] = 0;
-      //        chunkSizes[1] = ckptSize;
-      gRankList[0] = FTI_Topo->headRank;
-      gRankList[1] = FTI_Topo->myRank;
-      file_map[0] = 0;
-      file_map[1] = 0;
-      rank_map[0] = gRankList[0];
-      rank_map[1] = gRankList[1];
-
-   } else {
-
-      nlocaltasks = 1;
-      gRankList = talloc(int, 1);
-      chunkSizes = talloc(sion_int64, 1);
-      file_map = talloc(int, 1);
-      rank_map = talloc(int, 1);
-
-      //        *chunkSizes = ckptSize;
-      *gRankList = FTI_Topo->myRank;
-      *file_map = 0;
-      *rank_map = *gRankList;
-
-   }
-
-   sid = sion_paropen_mapped_mpi(gfn, "rb,posix", &numFiles, FTI_COMM_WORLD, &nlocaltasks, &gRankList, &chunkSizes, &file_map, &rank_map, &fsblksize, &dfp);
-
-   free(gRankList);
-   free(chunkSizes);
-   free(file_map);
-   free(rank_map);
-
-   lfd = fopen(lfn, "wb");
+   FILE* lfd = fopen(lfn, "wb");
    if (lfd == NULL) {
       FTI_Print("R4 cannot open the local ckpt. file.", FTI_DBUG);
+      sion_parclose_mapped_mpi(sid);
+      free(file_map);
+      free(ranks);
+      free(rank_map);
+      free(chunkSizes);
       return FTI_NSCS;
    }
 
-   char *blBuf1 = talloc(char, FTI_Conf->blockSize);
-
-   res = sion_seek(sid, FTI_Topo->myRank, SION_CURRENT_BLK, SION_CURRENT_POS);
+   res = sion_seek(sid, FTI_Topo->splitRank, SION_CURRENT_BLK, SION_CURRENT_POS);
    // check if successful
    if (res != SION_SUCCESS) {
       FTI_Print("SIONlib: Could not set file pointer", FTI_EROR);
-      sion_parclose_mapped_mpi(FTI_Exec->sid);
-      free(blBuf1);
+      sion_parclose_mapped_mpi(sid);
+      free(file_map);
+      free(ranks);
+      free(rank_map);
+      free(chunkSizes);
       fclose(lfd);
       return FTI_NSCS;
    }
 
-
    // Checkpoint files transfer from PFS
    while (!sion_feof(sid)) {
-
-      chunksize = FTI_Exec->meta[0].fs;
-
-      nbBlocks = chunksize / FTI_Conf->blockSize;
-      block = 0;
-      lastBlockBytes = chunksize % FTI_Conf->blockSize;
-
-
-      while (block < nbBlocks) {
-
-         res = sion_fread(blBuf1, sizeof(char), FTI_Conf->blockSize, sid);
-         if (res != FTI_Conf->blockSize) {
-            sprintf(str, "SIONlib: Unable to read %i Bytes from file", FTI_Conf->blockSize);
+      long fs = FTI_Exec->meta[4].fs[0];
+      char *readData = talloc(char, FTI_Conf->transferSize);
+      long bSize = FTI_Conf->transferSize;
+      long pos = 0;
+      // Checkpoint files transfer from PFS
+      while (pos < fs) {
+         if ((fs - pos) < FTI_Conf->transferSize) {
+             bSize = fs - pos;
+         }
+         res = sion_fread(readData, sizeof(char), bSize, sid);
+         if (res != bSize) {
+            sprintf(str, "SIONlib: Unable to read %lu Bytes from file", bSize);
             FTI_Print(str, FTI_EROR);
-            sion_parclose_mapped_mpi(FTI_Exec->sid);
-            free(blBuf1);
+            sion_parclose_mapped_mpi(sid);
+            free(file_map);
+            free(ranks);
+            free(rank_map);
+            free(chunkSizes);
+            free(readData);
             fclose(lfd);
             return FTI_NSCS;
          }
 
-         fwrite(blBuf1, sizeof(char), FTI_Conf->blockSize, lfd);
+         fwrite(readData, sizeof(char), bSize, lfd);
          if (ferror(lfd)) {
             FTI_Print("R4 cannot write to the local ckpt. file.", FTI_DBUG);
-            free(blBuf1);
+            free(readData);
             fclose(lfd);
-            sion_parclose_mapped_mpi(FTI_Exec->sid);
+            sion_parclose_mapped_mpi(sid);
+            free(file_map);
+            free(ranks);
+            free(rank_map);
+            free(chunkSizes);
             return  FTI_NSCS;
          }
 
-         block++;
+         pos = pos + bSize;
       }
-
-      res = sion_fread(blBuf1, sizeof(char), lastBlockBytes, sid);
-      if (res != lastBlockBytes) {
-         sprintf(str, "SIONlib: Unable to read data %i Bytes from file", FTI_Conf->blockSize);
-         FTI_Print(str, FTI_EROR);
-         sion_parclose_mapped_mpi(FTI_Exec->sid);
-         free(blBuf1);
-         fclose(lfd);
-         return FTI_NSCS;
-      }
-
-      fwrite(blBuf1, sizeof(char), lastBlockBytes, lfd);
-      if (ferror(lfd)) {
-         FTI_Print("R4 cannot write to the local ckpt. file.", FTI_DBUG);
-         free(blBuf1);
-         fclose(lfd);
-         sion_parclose_mapped_mpi(FTI_Exec->sid);
-         return  FTI_NSCS;
-      }
-
-
+      free(readData);
    }
-   free(blBuf1);
 
    fclose(lfd);
 
    sion_parclose_mapped_mpi(sid);
+   free(file_map);
+   free(ranks);
+   free(rank_map);
+   free(chunkSizes);
 
    return FTI_SCES;
 }

--- a/src/recover.c
+++ b/src/recover.c
@@ -58,11 +58,7 @@ int FTI_CheckFile(char* fn, unsigned long fs, char* checksum)
     @param      FTI_Exec        Execution metadata.
     @param      FTI_Topo        Topology metadata.
     @param      FTI_Ckpt        Checkpoint metadata.
-    @param      fs              The ckpt. file size for this process.
-    @param      maxFs           The max. ckpt. file size in the group.
-    @param      group           The group ID.
     @param      erased          The array of erasures to fill.
-    @param      level           The ckpt. level to check for erasures.
     @return     integer         FTI_SCES if successful.
 
     This function detects all the erasures for L1, L2 and L3. It return the
@@ -73,61 +69,52 @@ int FTI_CheckFile(char* fn, unsigned long fs, char* checksum)
 /*-------------------------------------------------------------------------*/
 int FTI_CheckErasures(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                       FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
-                      unsigned long *fs, unsigned long *maxFs, int group,
-                      int *erased, int level)
+                      int *erased)
 {
     int buf;
+    int ckptID, rank;
+    int level = FTI_Exec->ckptLvel;
     char fn[FTI_BUFS];
     char checksum[MD5_DIGEST_LENGTH], ptnerChecksum[MD5_DIGEST_LENGTH], rsChecksum[MD5_DIGEST_LENGTH];
-    unsigned long pfs;
-    if (FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, fs, maxFs, group, level) == FTI_SCES) {
-        FTI_Print("Metadata obtained.", FTI_DBUG);
-    }
-    else {
-        FTI_Print("Error getting metadata.", FTI_WARN);
-        return FTI_NSCS;
-    }
+    long fs = FTI_Exec->meta[level].fs[0];
+    long pfs = FTI_Exec->meta[level].pfs[0];
+    long maxFs = FTI_Exec->meta[level].maxFs[0];
+    char ckptFile[FTI_BUFS];
+    strcpy(ckptFile, FTI_Exec->meta[level].ckptFile);
+
     // TODO Checksums only local currently
     if ( level > 0 && level < 4 ) {
-        FTI_GetChecksums(FTI_Conf, FTI_Topo, FTI_Ckpt, checksum, ptnerChecksum, rsChecksum, group, level);
-        sprintf(fn, "Checking file %s and its erasures.", FTI_Exec->ckptFile);
-        FTI_Print(fn, FTI_DBUG);
+        FTI_GetChecksums(FTI_Conf, FTI_Topo, FTI_Ckpt, checksum, ptnerChecksum, rsChecksum, FTI_Topo->groupID, level);
     }
+    sprintf(fn, "Checking file %s and its erasures.", ckptFile);
+    FTI_Print(fn, FTI_DBUG);
     switch (level) {
         case 1:
-            sprintf(fn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec->ckptFile);
-            buf = FTI_CheckFile(fn, *fs, checksum);
+            sprintf(fn, "%s/%s", FTI_Ckpt[1].dir, ckptFile);
+            buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
             break;
         case 2:
-            sprintf(fn, "%s/%s", FTI_Ckpt[2].dir, FTI_Exec->ckptFile);
-            buf = FTI_CheckFile(fn, *fs, checksum);
+            sprintf(fn, "%s/%s", FTI_Ckpt[2].dir, ckptFile);
+            buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
-
-            if (FTI_GetPtnerSize(FTI_Conf, FTI_Topo, FTI_Ckpt, &pfs, group, 2) == FTI_SCES) {
-                FTI_Print("PtnerSize obtained.", FTI_DBUG);
-            }
-            else {
-                FTI_Print("Error getting ptnerSize.", FTI_WARN);
-                return FTI_NSCS;
-            }
-            sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &buf);
-            sprintf(fn, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, FTI_Exec->ckptID, buf);
+            sscanf(ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank);
+            sprintf(fn, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, ckptID, rank);
             buf = FTI_CheckFile(fn, pfs, ptnerChecksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased + FTI_Topo->groupSize, 1, MPI_INT, FTI_Exec->groupComm);
             break;
         case 3:
-            sprintf(fn, "%s/%s", FTI_Ckpt[3].dir, FTI_Exec->ckptFile);
-            buf = FTI_CheckFile(fn, *fs, checksum);
+            sprintf(fn, "%s/%s", FTI_Ckpt[3].dir, ckptFile);
+            buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
-            sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &FTI_Exec->ckptID, &buf);
-            sprintf(fn, "%s/Ckpt%d-RSed%d.fti", FTI_Ckpt[3].dir, FTI_Exec->ckptID, buf);
-            buf = FTI_CheckFile(fn, *maxFs, rsChecksum);
+            sscanf(ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank);
+            sprintf(fn, "%s/Ckpt%d-RSed%d.fti", FTI_Ckpt[3].dir, ckptID, rank);
+            buf = FTI_CheckFile(fn, maxFs, rsChecksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased + FTI_Topo->groupSize, 1, MPI_INT, FTI_Exec->groupComm);
             break;
         case 4:
-            sprintf(fn, "%s/%s", FTI_Ckpt[4].dir, FTI_Exec->ckptFile);
-            buf = FTI_CheckFile(fn, *fs, "");
+            sprintf(fn, "%s/%s", FTI_Ckpt[4].dir, ckptFile);
+            buf = FTI_CheckFile(fn, fs, "");
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
             break;
     }
@@ -155,74 +142,56 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
    int r, tres = FTI_SCES, id, level = 1;
    unsigned long fs, maxFs;
    char str[FTI_BUFS];
+   FTI_LoadMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
    if (!FTI_Topo->amIaHead) {
       while (level < 5) {
          if ((FTI_Exec->reco == 2) && (level != 4)) {
             tres = FTI_NSCS;
          }
          else {
-            if (FTI_GetMeta(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, &fs, &maxFs, FTI_Topo->groupID, level) != FTI_SCES) {
-               tres = FTI_NSCS;
-            }
-            else {
-               FTI_Exec->meta[0].fs = fs;
-               FTI_Exec->meta[0].maxFs = maxFs;
-               FTI_Exec->ckptLvel = level;
-               switch (FTI_Exec->ckptLvel) {
-                  case 4:
-                     FTI_Clean(FTI_Conf, FTI_Topo, FTI_Ckpt, 1, FTI_Topo->groupID, FTI_Topo->myRank);
-                     MPI_Barrier(FTI_COMM_WORLD);
-                     switch(FTI_Conf->ioMode) {
-
-                        case FTI_IO_POSIX:
-
-                           sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &id, &r);
-                           break;
-
-                        case FTI_IO_MPI:
-
-                           sscanf(FTI_Exec->ckptFile, "Ckpt%d-mpiio.fti", &id);
-                           break;
-#ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-                        case FTI_IO_SIONLIB:
-
-                           sscanf(FTI_Exec->ckptFile, "Ckpt%d-sionlib.fti", &id);
-                           break;
-#endif
-                     }
-                     sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
-                     FTI_Print(str, FTI_DBUG);
-                     FTI_Exec->ckptID = id;
-                     FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
-                     r = FTI_RecoverL4(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, FTI_Topo->groupID);
-                     break;
-                  case 3:
-                     sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &id, &r);
-                     sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
-                     FTI_Print(str, FTI_DBUG);
-                     FTI_Exec->ckptID = id;
-                     FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
-                     r = FTI_RecoverL3(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, FTI_Topo->groupID);
-                     break;
-                  case 2:
-                     sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &id, &r);
-                     sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
-                     FTI_Print(str, FTI_DBUG);
-                     FTI_Exec->ckptID = id;
-                     FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
-                     r = FTI_RecoverL2(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, FTI_Topo->groupID);
-                     break;
-                  case 1:
-                     sscanf(FTI_Exec->ckptFile, "Ckpt%d-Rank%d.fti", &id, &r);
-                     sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
-                     FTI_Print(str, FTI_DBUG);
-                     FTI_Exec->ckptID = id;
-                     FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
-                     r = FTI_RecoverL1(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, FTI_Topo->groupID);
-                     break;
+               if (FTI_Exec->meta[level].exists[0]) {
+                   FTI_Exec->ckptLvel = level;
+                   switch (FTI_Exec->ckptLvel) {
+                      case 4:
+                         FTI_Clean(FTI_Conf, FTI_Topo, FTI_Ckpt, 1, FTI_Topo->groupID, FTI_Topo->myRank);
+                         MPI_Barrier(FTI_COMM_WORLD);
+                         sscanf(FTI_Exec->meta[4].ckptFile, "Ckpt%d", &id);
+                         sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
+                         FTI_Print(str, FTI_DBUG);
+                         FTI_Exec->ckptID = id;
+                         FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
+                         r = FTI_RecoverL4(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+                         break;
+                      case 3:
+                         sscanf(FTI_Exec->meta[3].ckptFile, "Ckpt%d", &id);
+                         sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
+                         FTI_Print(str, FTI_DBUG);
+                         FTI_Exec->ckptID = id;
+                         FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
+                         r = FTI_RecoverL3(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+                         break;
+                      case 2:
+                         sscanf(FTI_Exec->meta[2].ckptFile, "Ckpt%d", &id);
+                         sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
+                         FTI_Print(str, FTI_DBUG);
+                         FTI_Exec->ckptID = id;
+                         FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
+                         r = FTI_RecoverL2(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+                         break;
+                      case 1:
+                         sscanf(FTI_Exec->meta[1].ckptFile, "Ckpt%d", &id);
+                         sprintf(str, "Trying recovery with Ckpt. %d at level %d.", id, level);
+                         FTI_Print(str, FTI_DBUG);
+                         FTI_Exec->ckptID = id;
+                         FTI_Exec->lastCkptLvel = FTI_Exec->ckptLvel;
+                         r = FTI_RecoverL1(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
+                         break;
+                   }
+                   MPI_Allreduce(&r, &tres, 1, MPI_INT, MPI_SUM, FTI_COMM_WORLD);
                }
-               MPI_Allreduce(&r, &tres, 1, MPI_INT, MPI_SUM, FTI_COMM_WORLD);
-            }
+               else {
+                   tres = FTI_NSCS;
+               }
          }
 
          if (tres == FTI_SCES) {

--- a/src/tools.c
+++ b/src/tools.c
@@ -140,6 +140,60 @@ int FTI_Try(int result, char* message)
 
 /*-------------------------------------------------------------------------*/
 /**
+    @brief      It mallocs memory for the metadata.
+    @param      FTI_Exec        Execution metadata.
+    @param      FTI_Topo        Topology metadata.
+
+    This function mallocs the memory used for the metadata storage.
+
+ **/
+/*-------------------------------------------------------------------------*/
+void FTI_MallocMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo)
+{
+    int i;
+    if (FTI_Topo->amIaHead) {
+        for (i = 0; i < 5; i++) {
+            FTI_Exec->meta[i].exists = calloc(FTI_Topo->nodeSize, sizeof(int));
+            FTI_Exec->meta[i].maxFs = calloc(FTI_Topo->nodeSize, sizeof(long));
+            FTI_Exec->meta[i].fs = calloc(FTI_Topo->nodeSize, sizeof(long));
+            FTI_Exec->meta[i].pfs = calloc(FTI_Topo->nodeSize, sizeof(long));
+            FTI_Exec->meta[i].ckptFile = calloc(FTI_BUFS * FTI_Topo->nodeSize, sizeof(char));
+        }
+    } else {
+        for (i = 0; i < 5; i++) {
+            FTI_Exec->meta[i].exists = calloc(1, sizeof(int));
+            FTI_Exec->meta[i].maxFs = calloc(1, sizeof(long));
+            FTI_Exec->meta[i].fs = calloc(1, sizeof(long));
+            FTI_Exec->meta[i].pfs = calloc(1, sizeof(long));
+            FTI_Exec->meta[i].ckptFile = calloc(FTI_BUFS, sizeof(char));
+        }
+    }
+}
+
+/*-------------------------------------------------------------------------*/
+/**
+    @brief      It frees memory for the metadata.
+    @param      FTI_Exec        Execution metadata.
+    @param      FTI_Topo        Topology metadata.
+
+    This function frees the memory used for the metadata storage.
+
+ **/
+/*-------------------------------------------------------------------------*/
+void FTI_FreeMeta(FTIT_execution* FTI_Exec)
+{
+    int i;
+    for (i = 0; i < 5; i++) {
+        free(FTI_Exec->meta[i].exists);
+        free(FTI_Exec->meta[i].maxFs);
+        free(FTI_Exec->meta[i].fs);
+        free(FTI_Exec->meta[i].pfs);
+        free(FTI_Exec->meta[i].ckptFile);
+    }
+}
+
+/*-------------------------------------------------------------------------*/
+/**
     @brief      It creates the basic datatypes and the dataset array.
     @param      FTI_Data        Dataset metadata.
     @return     integer         FTI_SCES if successful.


### PR DESCRIPTION
1. Changed storage of metadata in FTI.
2. Changed loading of metadata (FTI_LoadMeta loads meta for all levels, FTI_LoadTmpMeta loads only temporary metadata (used by head in post-processing)).
3. Changed way that heads do post-processing (now cleaner code, using for loop for every process in node).
4. Changed code of Flush to L4 (code is simpler and more modular).
5. Changed code of recover from L4  (code is simpler and more modular).

In my opinion this and more code refactorization are needed to further developing FTI.