### PR TITLE
Lustre support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,6 @@ append_property(TARGET fti.static fti.shared
 	PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
 set_property(TARGET fti.static fti.shared
 	PROPERTY OUTPUT_NAME fti)
-append_property(TARGET fti.static fti.shared
-    PROPERTY COMPILE_FLAGS -fPIC)
 
 #PGCC C and C++ use builtin math functions, which are much more efficient than library calls.
 #http://www.cecalc.ula.ve/documentacion/tutoriales/HPF/pgiws_ug/pgi30u09.htm
@@ -141,8 +139,6 @@ if(ENABLE_FORTRAN)
 		PROPERTY LINK_FLAGS "${MPI_Fortran_LINK_FLAGS} ${MPI_C_LINK_FLAGS}")
 	set_property(TARGET fti_f90.static fti_f90.shared
 		PROPERTY OUTPUT_NAME fti_f90)
-    append_property(TARGET fti_f90.static fti_f90.shared
-        PROPERTY COMPILE_FLAGS -fPIC)
 
 	list(APPEND FTI_TARGETS fti_f90.static fti_f90.shared)
 	install(TARGETS fti_f90.static fti_f90.shared

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,12 @@ if(ENABLE_LUSTRE)
         target_link_libraries(fti.static ${LUSTREAPI_LIBRARIES})
         target_link_libraries(fti.shared ${LUSTREAPI_LIBRARIES})
     else()
-        message(WARNING    "** Lustre could not be found!
-                            *  You may specify:
-                            *  -DLUSTREAPI_CMAKE_LIBRARY_DIRS:PATH=<path to liblustreapi.a>
-                            *  and
-                            *  -DLUSTREAPI_CMAKE_INCLUDE_DIRS:PATH=<path to liblustreapi.h>")
+        message(WARNING    "
+        ** Lustre could not be found!
+        *  You may specify:
+        *  -DLUSTREAPI_CMAKE_LIBRARY_DIRS:PATH=<path to liblustreapi.a>
+        *  and
+        *  -DLUSTREAPI_CMAKE_INCLUDE_DIRS:PATH=<path to liblustreapi.h>")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(MPI REQUIRED)
 find_package(OPENSSL REQUIRED)
 
 if(ENABLE_LUSTRE)
-    find_package(LUSTREAPI REQUIRED)
+    find_package(LUSTREAPI)
 endif()
 
 add_subdirectory(deps)
@@ -77,11 +77,19 @@ endif()
 target_link_libraries(fti.static ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}")
 target_link_libraries(fti.shared ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}")
 
-if(LUSTREAPI_FOUND)
-    append_property(SOURCE PROPERTY INCLUDE_DIRECTORIES ${LUSTREAPI_INCLUDE_DIRS})
-    append_property(SOURCE PROPERTY COMPILE_DEFINITIONS -DLUSTRE)
-    target_link_libraries(fti.static ${LUSTREAPI_LIBRARIES})
-    target_link_libraries(fti.shared ${LUSTREAPI_LIBRARIES})
+if(ENABLE_LUSTRE)
+    if(LUSTREAPI_FOUND)
+        include_directories(${LUSTREAPI_INCLUDE_DIRS})
+        append_property(SOURCE ${SRC_FTI} PROPERTY COMPILE_DEFINITIONS LUSTRE)
+        target_link_libraries(fti.static ${LUSTREAPI_LIBRARIES})
+        target_link_libraries(fti.shared ${LUSTREAPI_LIBRARIES})
+    else()
+        message(WARNING    "** Lustre could not be found!
+                            *  You may specify:
+                            *  -DLUSTREAPI_CMAKE_LIBRARY_DIRS:PATH=<path to liblustreapi.a>
+                            *  and
+                            *  -DLUSTREAPI_CMAKE_INCLUDE_DIRS:PATH=<path to liblustreapi.h>")
+    endif()
 endif()
 
 if(ENABLE_SIONLIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,12 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
 option(ENABLE_FORTRAN "Enables the generation of the Fortran wrapper for FTI" ON)
-option(ENABLE_EXAMPLES "Enables the generation of examples" ON) 
+option(ENABLE_EXAMPLES "Enables the generation of examples" ON)
 option(ENABLE_SIONLIB "Enables the parallel I/O SIONlib for FTI" OFF)
 option(ENABLE_TESTS "Enables the generation of tests" ON)
+option(ENABLE_LUSTRE "Enables Lustre Support" OFF)
+
+set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeScripts")
 include(AppendProperty)
@@ -19,6 +22,10 @@ include(FortranCInterface)
 
 find_package(MPI REQUIRED)
 find_package(OPENSSL REQUIRED)
+
+if(ENABLE_LUSTRE)
+    find_package(LUSTREAPI REQUIRED)
+endif()
 
 add_subdirectory(deps)
 
@@ -58,6 +65,8 @@ append_property(TARGET fti.static fti.shared
 	PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
 set_property(TARGET fti.static fti.shared
 	PROPERTY OUTPUT_NAME fti)
+append_property(TARGET fti.static fti.shared
+    PROPERTY COMPILE_FLAGS -fPIC)
 
 #PGCC C and C++ use builtin math functions, which are much more efficient than library calls.
 #http://www.cecalc.ula.ve/documentacion/tutoriales/HPF/pgiws_ug/pgi30u09.htm
@@ -68,8 +77,15 @@ endif()
 target_link_libraries(fti.static ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}")
 target_link_libraries(fti.shared ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}")
 
+if(LUSTREAPI_FOUND)
+    append_property(SOURCE PROPERTY INCLUDE_DIRECTORIES ${LUSTREAPI_INCLUDE_DIRS})
+    append_property(SOURCE PROPERTY COMPILE_DEFINITIONS -DLUSTRE)
+    target_link_libraries(fti.static ${LUSTREAPI_LIBRARIES})
+    target_link_libraries(fti.shared ${LUSTREAPI_LIBRARIES})
+endif()
+
 if(ENABLE_SIONLIB)
-    set(SIONLIBBASE "" CACHE FILEPATH "base path to SIONlib installation") 
+    set(SIONLIBBASE "" CACHE FILEPATH "base path to SIONlib installation")
     set(SIONLIB_INCLUDE_DIR "${SIONLIBBASE}/include/")
     include_directories("${SIONLIB_INCLUDE_DIR}")
     set(SIONLIB_CFLAGS "-I${SIONLIB_INCLUDE_DIR} -DSION_DEBUG -D_SION_LINUX  -DSION_MPI")
@@ -89,12 +105,12 @@ install(FILES "include/fti.h"
 
 if(ENABLE_FORTRAN)
 	add_subdirectory(vendor/bpp/ bpp/ EXCLUDE_FROM_ALL)
-	
+
 	bpp_preprocess(BPP_FTI_F90
 		src/fortran/interface.F90.bpp)
-		
+
 	add_custom_target(bpp_file DEPENDS "${BPP_FTI_F90}") # to serialize src generation
-	
+
 	set(SRC_FTI_F90 ${BPP_FTI_F90}
 		src/fortran/ftif.c)
 	append_property(SOURCE ${SRC_FTI_F90}
@@ -116,6 +132,8 @@ if(ENABLE_FORTRAN)
 		PROPERTY LINK_FLAGS "${MPI_Fortran_LINK_FLAGS} ${MPI_C_LINK_FLAGS}")
 	set_property(TARGET fti_f90.static fti_f90.shared
 		PROPERTY OUTPUT_NAME fti_f90)
+    append_property(TARGET fti_f90.static fti_f90.shared
+        PROPERTY COMPILE_FLAGS -fPIC)
 
 	list(APPEND FTI_TARGETS fti_f90.static fti_f90.shared)
 	install(TARGETS fti_f90.static fti_f90.shared

--- a/CMakeScripts/FindLUSTREAPI.cmake
+++ b/CMakeScripts/FindLUSTREAPI.cmake
@@ -16,7 +16,7 @@ find_path(
 
 find_library(
     LUSTREAPI_LIBRARY
-    NAMES liblustreapi.so ${LUSTREAPI_CMAKE_LIBRARIES}
+    NAMES liblustreapi.a ${LUSTREAPI_CMAKE_LIBRARIES}
     HINTS /usr/lib ${LUSTREAPI_CMAKE_LIBRARY_DIRS})
 
 include(

--- a/CMakeScripts/FindLUSTREAPI.cmake
+++ b/CMakeScripts/FindLUSTREAPI.cmake
@@ -1,0 +1,37 @@
+# Author: Kai Keller, 2017
+# Package to link the Lustre API
+
+# Sets variables:
+#    LUSTREAPI_FOUND
+#    LUSTREAPI_INCLUDE_DIRS
+#    LUSTREAPI_LIBRARIES
+#    LUSTREAPI_DEFINITIONS
+
+set(
+    LUSTREAPI_DEFINITIONS -DLUSTRE ${LUSTREAPI_CMAKE_DEFINITIONS})
+
+find_path(
+    LUSTREAPI_INCLUDE_DIR liblustreapi.h 
+    HINTS /usr/include/lustre ${LUSTREAPI_CMAKE_INCLUDE_DIRS})
+
+find_library(
+    LUSTREAPI_LIBRARY
+    NAMES liblustreapi.so ${LUSTREAPI_CMAKE_LIBRARIES}
+    HINTS /usr/lib ${LUSTREAPI_CMAKE_LIBRARY_DIRS})
+
+include(
+    FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    LUSTREAPI DEFAULT_MSG
+    LUSTREAPI_LIBRARY
+    LUSTREAPI_INCLUDE_DIR)
+
+mark_as_advanced(
+    LUSTREAPI_INCLUDE_DIR 
+    LUSTREAPI_LIBRARY)
+
+set(
+    LUSTREAPI_INCLUDE_DIRS ${LUSTREAPI_INCLUDE_DIR})
+set(
+    LUSTREAPI_LIBRARIES ${LUSTREAPI_LIBRARY})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(hd.exe heatdis.c)
 target_link_libraries(hd.exe fti.static ${MPI_C_LIBRARIES} m)
 set_property(TARGET hd.exe APPEND PROPERTY COMPILE_FLAGS ${MPI_C_COMPILE_FLAGS})
-set_property(TARGET hd.exe APPEND PROPERTY LINK_FLAGS ${MPI_C_LINK_FLAGS} "-Wl,-rpath,/usr/lib64")
+set_property(TARGET hd.exe APPEND PROPERTY LINK_FLAGS ${MPI_C_LINK_FLAGS})
 
 add_executable(hd2.exe heatd2.c)
 target_link_libraries(hd2.exe fti.static ${MPI_C_LIBRARIES} m)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(hd.exe heatdis.c)
 target_link_libraries(hd.exe fti.static ${MPI_C_LIBRARIES} m)
 set_property(TARGET hd.exe APPEND PROPERTY COMPILE_FLAGS ${MPI_C_COMPILE_FLAGS})
-set_property(TARGET hd.exe APPEND PROPERTY LINK_FLAGS ${MPI_C_LINK_FLAGS})
+set_property(TARGET hd.exe APPEND PROPERTY LINK_FLAGS ${MPI_C_LINK_FLAGS} "-Wl,-rpath,/usr/lib64")
 
 add_executable(hd2.exe heatd2.c)
 target_link_libraries(hd2.exe fti.static ${MPI_C_LIBRARIES} m)

--- a/include/fti.h
+++ b/include/fti.h
@@ -186,6 +186,11 @@ typedef struct FTIT_configuration {
     int             verbosity;          /**< Verbosity level.               */
     int             blockSize;          /**< Communication block size.      */
     int             transferSize;       /**< Transfer size local to PFS     */
+#ifdef LUSTRE    
+    int             stripeUnit;         /**< Striping Unit for Lustre FS    */
+    int             stripeOffset;       /**< Striping Offset for Lustre FS  */
+    int             stripeFactor;       /**< Striping Factor for Lustre FS  */
+#endif
     int             tag;                /**< Tag for MPI messages in FTI.   */
     int             test;               /**< TRUE if local test.            */
     int             l3WordSize;         /**< RS encoding word size.         */

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -5,7 +5,10 @@
  *  @brief  Checkpointing functions for the FTI library.
  */
 
-#define _POSIX_C_SOURCE 200809L
+#ifndef LUSTRE
+#    define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <string.h>
 
 #include "interface.h"
@@ -395,6 +398,7 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_WriteMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
       FTIT_topology* FTI_Topo, FTIT_dataset* FTI_Data)
 {
+   int res;
    FTI_Print("I/O mode: MPI-IO.", FTI_DBUG);
    char str[FTI_BUFS], mpi_err[FTI_BUFS];
 
@@ -418,7 +422,20 @@ int FTI_WriteMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
    sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, ckptFile);
    // open parallel file (collective call)
    MPI_File pfh;
-   int res = MPI_File_open(FTI_COMM_WORLD, gfn, MPI_MODE_WRONLY|MPI_MODE_CREATE, info, &pfh);
+
+#ifdef LUSTRE
+    if (FTI_Topo->splitRank == 0) {
+        res = llapi_file_create(gfn, FTI_Conf->stripeUnit, FTI_Conf->stripeOffset, FTI_Conf->stripeFactor, 0);
+        if (res) {
+            char error_msg[FTI_BUFS];
+            error_msg[0] = 0;
+            strerror_r(-res, error_msg, FTI_BUFS);
+            sprintf(str, "[Lustre] %s.", error_msg);
+            FTI_Print(str, FTI_WARN);
+        }
+    }
+#endif
+   res = MPI_File_open(FTI_COMM_WORLD, gfn, MPI_MODE_WRONLY|MPI_MODE_CREATE, info, &pfh);
 
    // check if successful
    if (res != 0) {

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -430,8 +430,12 @@ int FTI_WriteMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             char error_msg[FTI_BUFS];
             error_msg[0] = 0;
             strerror_r(-res, error_msg, FTI_BUFS);
-            sprintf(str, "[Lustre] %s.", error_msg);
+            snprintf(str, FTI_BUFS, "[Lustre] %s.", error_msg);
             FTI_Print(str, FTI_WARN);
+        } else {
+            snprintf(str, FTI_BUFS, "[LUSTRE] file:%s striping_unit:%i striping_factor:%i striping_offset:%i", 
+                    ckptFile, FTI_Conf->stripeUnit, FTI_Conf->stripeFactor, FTI_Conf->stripeOffset);
+            FTI_Print(str, FTI_DBUG);
         }
     }
 #endif

--- a/src/conf.c
+++ b/src/conf.c
@@ -132,6 +132,11 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FTI_Conf->test = (int)iniparser_getint(ini, "Advanced:local_test", -1);
     FTI_Conf->l3WordSize = FTI_WORD;
     FTI_Conf->ioMode = (int)iniparser_getint(ini, "Basic:ckpt_io", 0) + 1000;
+#ifdef LUSTRE
+    FTI_Conf->stripeUnit = (int)iniparser_getint(ini, "Advanced:lustre_stiping_unit", 4194304);
+    FTI_Conf->stripeFactor = (int)iniparser_getint(ini, "Advanced:lustre_stiping_factor", -1);
+    FTI_Conf->stripeOffset = (int)iniparser_getint(ini, "Advanced:lustre_stiping_offset", -1);
+#endif
 
     // Reading/setting execution metadata
     FTI_Exec->nbVar = 0;

--- a/src/interface.h
+++ b/src/interface.h
@@ -17,7 +17,7 @@
 #include "../deps/jerasure/jerasure.h"
 
 #ifdef ENABLE_SIONLIB // --> If SIONlib is installed
-    #include <sion.h>
+#   include <sion.h>
 #endif
 
 #include <stdint.h>
@@ -32,6 +32,11 @@
 #include <errno.h>
 #include <math.h>
 #include <limits.h>
+
+#ifdef LUSTRE
+#   include "lustreapi.h"
+#endif
+
 
 /*---------------------------------------------------------------------------
                                   Defines

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -580,9 +580,9 @@ int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     // open parallel file (collective call)
     MPI_File pfh; // MPI-IO file handle
-    char gfn[FTI_BUFS], lfn[FTI_BUFS], str[FTI_BUFS];
-    snprintf(str, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
-    sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, str);
+    char gfn[FTI_BUFS], lfn[FTI_BUFS], str[FTI_BUFS], ckptFile[FTI_BUFS];
+    snprintf(ckptFile, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
+    sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, ckptFile);
 #ifdef LUSTRE
     if (FTI_Topo->splitRank == 0) {
         res = llapi_file_create(gfn, FTI_Conf->stripeUnit, FTI_Conf->stripeOffset, FTI_Conf->stripeFactor, 0);
@@ -592,6 +592,10 @@ int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             strerror_r(-res, error_msg, FTI_BUFS);
             sprintf(str, "[Lustre] %s.", error_msg);
             FTI_Print(str, FTI_WARN);
+        } else {
+            snprintf(str, FTI_BUFS, "[LUSTRE] file:%s striping_unit:%i striping_factor:%i striping_offset:%i", 
+                    ckptFile, FTI_Conf->stripeUnit, FTI_Conf->stripeFactor, FTI_Conf->stripeOffset);
+            FTI_Print(str, FTI_DBUG);
         }
     }
 #endif

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -568,6 +568,7 @@ int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int level)
 {
+    int res;
     FTI_Print("Starting checkpoint post-processing L4 using MPI-IO.", FTI_DBUG);
     // enable collective buffer optimization
     MPI_Info info;
@@ -582,7 +583,19 @@ int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     char gfn[FTI_BUFS], lfn[FTI_BUFS], str[FTI_BUFS];
     snprintf(str, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
     sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, str);
-    int res = MPI_File_open(FTI_COMM_WORLD, gfn, MPI_MODE_WRONLY|MPI_MODE_CREATE, info, &pfh);
+#ifdef LUSTRE
+    if (FTI_Topo->splitRank == 0) {
+        res = llapi_file_create(gfn, FTI_Conf->stripeUnit, FTI_Conf->stripeOffset, FTI_Conf->stripeFactor, 0);
+        if (res) {
+            char error_msg[FTI_BUFS];
+            error_msg[0] = 0;
+            strerror_r(-res, error_msg, FTI_BUFS);
+            sprintf(str, "[Lustre] %s.", error_msg);
+            FTI_Print(str, FTI_WARN);
+        }
+    }
+#endif
+    res = MPI_File_open(FTI_COMM_WORLD, gfn, MPI_MODE_WRONLY|MPI_MODE_CREATE, info, &pfh);
     if (res != 0) {
        errno = 0;
        char mpi_err[FTI_BUFS];


### PR DESCRIPTION
Adds Lustre support for MPI-IO.

Config file options:
[Advanced]
lustre_stiping_unit (default = 4194304)
lustre_stiping_factor (dafault = -1)
lustre_stiping_offset (default = -1)

enable by adding `-DENABLE_LUSTRE=ON` to cmake command.