### PR TITLE
Hotfix mpiio

### DIFF
--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -487,12 +487,9 @@ int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     if (res != FTI_SCES) {
         return FTI_NSCS;
     }
-    //if (!FTI_Ckpt[4].isInline || FTI_Conf->ioMode == FTI_IO_POSIX) {
-    //    //Just copy checkpoint files to PFS if L4 post-processing done by heads
-    //    res = FTI_FlushPosix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
-    //}
-    //else {
+
     switch(FTI_Conf->ioMode) {
+        
         case FTI_IO_POSIX:
             FTI_FlushPosix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, level);
             break;

--- a/src/postreco.c
+++ b/src/postreco.c
@@ -694,11 +694,8 @@ int FTI_RecoverL3(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_RecoverL4(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
 {
-    //if (!FTI_Ckpt[4].isInline || FTI_Conf->ioMode == FTI_IO_POSIX) {
-    //    return FTI_RecoverL4Posix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
-    //}
-    //else {
         switch(FTI_Conf->ioMode) {
+            
             case FTI_IO_POSIX:
                 return FTI_RecoverL4Posix(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt);
             case FTI_IO_MPI:


### PR DESCRIPTION
fixes the case keep_last_ckpt = 1 for MPI-IO