### PR TITLE
This fixes compiler warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,9 @@ set(SRC_FTI
 	src/postckpt.c src/postreco.c src/recover.c
 	src/tools.c src/topo.c src/ftiff.c src/hdf5.c)
 
+set(ADD_CFLAGS "-fPIC -Wall -Wno-format-truncation")
 append_property(SOURCE ${SRC_FTI}
-    PROPERTY COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS}" "${SIONLIB_CFLAGS}" -fPIC)
+    PROPERTY COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS}" "${SIONLIB_CFLAGS}" "${ADD_CFLAGS}")
 
 if(${OPENSSL_FOUND})
 	add_library(fti.static STATIC ${SRC_FTI} ${OPENSSL_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeScripts")
 include(AppendProperty)
 include(FortranCInterface)
 include(CheckFortranCompilerFlag)
+include(CheckCCompilerFlag)
 
 find_package(MPI REQUIRED)
 if(NOT DEFINED NO_OPENSSL)
@@ -111,7 +112,25 @@ set(SRC_FTI
 	src/postckpt.c src/postreco.c src/recover.c
 	src/tools.c src/topo.c src/ftiff.c src/hdf5.c)
 
-set(ADD_CFLAGS "-fPIC -Wall -Wno-format-truncation")
+# Check compiler flag support
+set(ADD_CFLAGS "")
+try_compile(C_COMPILER_HAS_FLAG ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake/minimal.c COMPILE_DEFINITIONS "-fPIC")
+if(C_COMPILER_HAS_FLAG)
+    set(ADD_CFLAGS "${ADD_CFLAGS} -fPIC")
+endif()
+try_compile(C_COMPILER_HAS_FLAG ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake/minimal.c COMPILE_DEFINITIONS "-Wall")
+if(C_COMPILER_HAS_FLAG)
+    set(ADD_CFLAGS "${ADD_CFLAGS} -Wall")
+endif()
+try_compile(C_COMPILER_HAS_FLAG ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake/minimal.c COMPILE_DEFINITIONS "-Wno-format-truncation")
+if(C_COMPILER_HAS_FLAG)
+    set(ADD_CFLAGS "${ADD_CFLAGS} -Wno-format-truncation")
+endif()
+try_compile(C_COMPILER_HAS_FLAG ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake/minimal.c COMPILE_DEFINITIONS "-Minform=inform")
+if(C_COMPILER_HAS_FLAG)
+    set(ADD_CFLAGS "${ADD_CFLAGS} -Minform=inform")
+endif()
+
 append_property(SOURCE ${SRC_FTI}
     PROPERTY COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS}" "${SIONLIB_CFLAGS}" "${ADD_CFLAGS}")
 

--- a/src/api.c
+++ b/src/api.c
@@ -251,7 +251,7 @@ int FTI_InitComplexType(FTIT_type* newType, FTIT_complexType* typeDefinition, in
         for (j = 0; j < typeDefinition->field[i].rank; j++) {
             if (typeDefinition->field[i].dimLength[j] < 1) {
                 char str[FTI_BUFS];
-                sprintf(str, "(%s, index: %d) Type dimention length must be greater than 0.", typeDefinition->field[i].name, i);
+                snprintf(str, FTI_BUFS, "(%s, index: %d) Type dimention length must be greater than 0.", typeDefinition->field[i].name, i);
                 FTI_Print(str, FTI_WARN);
                 return FTI_NSCS;
             }
@@ -505,7 +505,7 @@ void* FTI_Realloc(int id, void* ptr)
 
     FTI_Print("Trying to reallocate dataset.", FTI_DBUG);
     if (FTI_Exec.reco) {
-        char fn[FTI_BUFS], str[FTI_BUFS];
+        char str[FTI_BUFS];
         int i;
         for (i = 0; i < FTI_BUFS; i++) {
             if (id == FTI_Data[i].id) {
@@ -798,10 +798,10 @@ int FTI_Recover()
 
     //Recovering from local for L4 case in FTI_Recover
     if (FTI_Exec.ckptLvel == 4) {
-        sprintf(fn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec.meta[1].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec.meta[1].ckptFile);
     }
     else {
-        sprintf(fn, "%s/%s", FTI_Ckpt[FTI_Exec.ckptLvel].dir, FTI_Exec.meta[FTI_Exec.ckptLvel].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[FTI_Exec.ckptLvel].dir, FTI_Exec.meta[FTI_Exec.ckptLvel].ckptFile);
     }
 
     sprintf(str, "Trying to load FTI checkpoint file (%s)...", fn);
@@ -1040,10 +1040,10 @@ int FTI_RecoverVar(int id)
 
     //Recovering from local for L4 case in FTI_Recover
     if (FTI_Exec.ckptLvel == 4) {
-        sprintf(fn, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec.meta[1].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[1].dir, FTI_Exec.meta[1].ckptFile);
     }
     else {
-        sprintf(fn, "%s/%s", FTI_Ckpt[FTI_Exec.ckptLvel].dir, FTI_Exec.meta[FTI_Exec.ckptLvel].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[FTI_Exec.ckptLvel].dir, FTI_Exec.meta[FTI_Exec.ckptLvel].ckptFile);
     }
 
     char str[FTI_BUFS];

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -83,16 +83,16 @@ int FTI_UpdateIterTime(FTIT_execution* FTI_Exec)
             if (res >= FTI_Exec->ckptIcnt) {
                 FTI_Exec->ckptNext = res;
             }
-            sprintf(str, "Current iter : %d ckpt intv. : %d . Next ckpt. at iter. %d . Sync. intv. : %d",
+            snprintf(str, FTI_BUFS, "Current iter : %d ckpt intv. : %d . Next ckpt. at iter. %d . Sync. intv. : %d",
                     FTI_Exec->ckptIcnt, FTI_Exec->ckptIntv, FTI_Exec->ckptNext, FTI_Exec->syncIter);
             FTI_Print(str, FTI_DBUG);
             if ((FTI_Exec->syncIter < (FTI_Exec->ckptIntv / 2)) && (FTI_Exec->syncIter < FTI_Exec->syncIterMax)) {
                 FTI_Exec->syncIter = FTI_Exec->syncIter * 2;
-                sprintf(str, "Iteration frequency : %.2f sec/iter => %d iter/min. Resync every %d iter.",
+                snprintf(str, FTI_BUFS, "Iteration frequency : %.2f sec/iter => %d iter/min. Resync every %d iter.",
                         FTI_Exec->globMeanIter, FTI_Exec->ckptIntv, FTI_Exec->syncIter);
                 FTI_Print(str, FTI_DBUG);
                 if (FTI_Exec->syncIter == FTI_Exec->syncIterMax) {
-                    sprintf(str, "Sync. intv. has reached max value => %i iterations", FTI_Exec->syncIterMax);
+                    snprintf(str, FTI_BUFS, "Sync. intv. has reached max value => %i iterations", FTI_Exec->syncIterMax);
                     FTI_Print(str, FTI_DBUG);
                 }
 
@@ -124,7 +124,7 @@ int FTI_WriteCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_dataset* FTI_Data)
 {
     char str[FTI_BUFS]; //For console output
-    sprintf(str, "Starting writing checkpoint (ID: %d, Lvl: %d)",
+    snprintf(str, FTI_BUFS, "Starting writing checkpoint (ID: %d, Lvl: %d)",
             FTI_Exec->ckptID, FTI_Exec->ckptLvel);
     FTI_Print(str, FTI_DBUG);
 
@@ -207,7 +207,7 @@ int FTI_WriteCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         return FTI_NSCS;
     }
 
-    sprintf(str, "Time writing checkpoint file : %f seconds.", MPI_Wtime() - tt);
+    snprintf(str, FTI_BUFS, "Time writing checkpoint file : %f seconds.", MPI_Wtime() - tt);
     FTI_Print(str, FTI_DBUG);
 
     res = FTI_Try(FTI_CreateMetadata(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, FTI_Data), "create metadata.");
@@ -269,7 +269,7 @@ int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     int nodeFlag = (((!FTI_Topo->amIaHead) && ((FTI_Topo->nodeRank - FTI_Topo->nbHeads) == 0)) || (FTI_Topo->amIaHead)) ? 1 : 0;
     if (nodeFlag) { //True only for one process in the node.
         //Debug message needed to test nodeFlag (./tests/nodeFlag/nodeFlag.c)
-        sprintf(str, "Has nodeFlag = 1 and nodeID = %d. CkptLvel = %d.", FTI_Topo->nodeID, FTI_Exec->ckptLvel);
+        snprintf(str, FTI_BUFS, "Has nodeFlag = 1 and nodeID = %d. CkptLvel = %d.", FTI_Topo->nodeID, FTI_Exec->ckptLvel);
         FTI_Print(str, FTI_DBUG);
         if (!(FTI_Ckpt[4].isInline && FTI_Exec->ckptLvel == 4)) {
             //checkpoint was not saved in global temporary directory
@@ -300,7 +300,7 @@ int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     double t3 = MPI_Wtime(); //Renaming directories time
 
-    sprintf(str, "Post-checkpoint took %.2f sec. (Pt:%.2fs, Cl:%.2fs)",
+    snprintf(str, FTI_BUFS, "Post-checkpoint took %.2f sec. (Pt:%.2fs, Cl:%.2fs)",
             t3 - t1, t2 - t1, t3 - t2);
     FTI_Print(str, FTI_INFO);
     return FTI_SCES;
@@ -338,7 +338,7 @@ int FTI_Listen(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         for (i = 0; i < FTI_Topo->nbApprocs; i++) { // Iterate on the application processes in the node
             int buf;
             MPI_Recv(&buf, 1, MPI_INT, FTI_Topo->body[i], FTI_Conf->tag, FTI_Exec->globalComm, MPI_STATUS_IGNORE);
-            sprintf(str, "The head received a %d message", buf);
+            snprintf(str, FTI_BUFS, "The head received a %d message", buf);
             FTI_Print(str, FTI_DBUG);
             flags[buf - FTI_BASE] = flags[buf - FTI_BASE] + 1;
         }
@@ -423,16 +423,16 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     char str[FTI_BUFS], fn[FTI_BUFS];
     int level = FTI_Exec->ckptLvel;
     if (level == 4 && FTI_Ckpt[4].isInline) { //If inline L4 save directly to global directory
-        sprintf(fn, "%s/%s", FTI_Conf->gTmpDir, FTI_Exec->meta[0].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, FTI_Exec->meta[0].ckptFile);
     }
     else {
-        sprintf(fn, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->meta[0].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->meta[0].ckptFile);
     }
 
     // open task local ckpt file
     FILE* fd = fopen(fn, "wb");
     if (fd == NULL) {
-        sprintf(str, "FTI checkpoint file (%s) could not be opened.", fn);
+        snprintf(str, FTI_BUFS, "FTI checkpoint file (%s) could not be opened.", fn);
         FTI_Print(str, FTI_EROR);
 
         return FTI_NSCS;
@@ -453,7 +453,7 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             char error_msg[FTI_BUFS];
             error_msg[0] = 0;
             strerror_r(fwrite_errno, error_msg, FTI_BUFS);
-            sprintf(str, "Dataset #%d could not be written: %s.", FTI_Data[i].id, error_msg);
+            snprintf(str, FTI_BUFS, "Dataset #%d could not be written: %s.", FTI_Data[i].id, error_msg);
             FTI_Print(str, FTI_EROR);
             fclose(fd);
             return FTI_NSCS;
@@ -512,7 +512,7 @@ int FTI_WriteMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     char gfn[FTI_BUFS], ckptFile[FTI_BUFS];
     snprintf(ckptFile, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
-    sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, ckptFile);
+    snprintf(gfn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, ckptFile);
     // open parallel file (collective call)
     MPI_File pfh;
 
@@ -618,7 +618,7 @@ int FTI_WriteSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     // open parallel file
     char fn[FTI_BUFS], str[FTI_BUFS];
     snprintf(str, FTI_BUFS, "Ckpt%d-sionlib.fti", FTI_Exec->ckptID);
-    sprintf(fn, "%s/%s", FTI_Conf->gTmpDir, str);
+    snprintf(fn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, str);
     int sid = sion_paropen_mapped_mpi(fn, "wb,posix", &numFiles, FTI_COMM_WORLD, &nlocaltasks, &ranks, &chunkSizes, &file_map, &rank_map, &fsblksize, NULL);
 
     // check if successful

--- a/src/conf.c
+++ b/src/conf.c
@@ -61,14 +61,14 @@ int FTI_UpdateConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, int r
 
     // Load dictionary
     dictionary* ini = iniparser_load(FTI_Conf->cfgFile);
-    sprintf(str, "Updating configuration file (%s)...", FTI_Conf->cfgFile);
+    snprintf(str, FTI_BUFS, "Updating configuration file (%s)...", FTI_Conf->cfgFile);
     FTI_Print(str, FTI_DBUG);
     if (ini == NULL) {
         FTI_Print("Iniparser failed to parse the conf. file.", FTI_WARN);
         return FTI_NSCS;
     }
 
-    sprintf(str, "%d", restart);
+    snprintf(str, FTI_BUFS, "%d", restart);
     // Set failure to 'restart'
     iniparser_set(ini, "Restart:failure", str);
     // Set the exec. ID
@@ -120,7 +120,7 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_injection* FTI_Inje)
 {
     char str[FTI_BUFS]; //For console output
-    sprintf(str, "Reading FTI configuration file (%s)...", FTI_Conf->cfgFile);
+    snprintf(str, FTI_BUFS, "Reading FTI configuration file (%s)...", FTI_Conf->cfgFile);
     FTI_Print(str, FTI_INFO);
 
     // Check access to FTI configuration file and load dictionary
@@ -195,13 +195,13 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         snprintf(FTI_Exec->id, FTI_BUFS, "%d-%02d-%02d_%02d-%02d-%02d",
                 n->tm_year + 1900, n->tm_mon + 1, n->tm_mday, n->tm_hour, n->tm_min, n->tm_sec);
         MPI_Bcast(FTI_Exec->id, FTI_BUFS, MPI_CHAR, 0, FTI_Exec->globalComm);
-        sprintf(str, "The execution ID is: %s", FTI_Exec->id);
+        snprintf(str, FTI_BUFS, "The execution ID is: %s", FTI_Exec->id);
         FTI_Print(str, FTI_INFO);
     }
     else {
         par = iniparser_getstring(ini, "restart:exec_id", NULL);
         snprintf(FTI_Exec->id, FTI_BUFS, "%s", par);
-        sprintf(str, "This is a restart. The execution ID is: %s", FTI_Exec->id);
+        snprintf(str, FTI_BUFS, "This is a restart. The execution ID is: %s", FTI_Exec->id);
         FTI_Print(str, FTI_INFO);
     }
 
@@ -311,7 +311,7 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
         }
         FTI_Exec->syncIterMax = check;
         char str[FTI_BUFS];
-        sprintf(str,"Maximal sync. intv. has to be a power of 2. Set to nearest lower value (%d iterations)", FTI_Exec->syncIterMax);
+        snprintf(str, FTI_BUFS, "Maximal sync. intv. has to be a power of 2. Set to nearest lower value (%d iterations)", FTI_Exec->syncIterMax);
         FTI_Print(str, FTI_WARN);
     } else if (FTI_Exec->syncIterMax == 0) {
         FTI_Exec->syncIterMax = 512;
@@ -369,7 +369,7 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
         char str[FTI_BUFS]; //For console output
 
         // Checking local directory
-        sprintf(str, "Checking the local directory (%s)...", FTI_Conf->localDir);
+        snprintf(str, FTI_BUFS, "Checking the local directory (%s)...", FTI_Conf->localDir);
         FTI_Print(str, FTI_DBUG);
         if (mkdir(FTI_Conf->localDir, 0777) == -1) {
             if (errno != EEXIST) {
@@ -380,7 +380,7 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
 
         if (FTI_Topo->myRank == 0) {
             // Checking metadata directory
-            sprintf(str, "Checking the metadata directory (%s)...", FTI_Conf->metadDir);
+            snprintf(str, FTI_BUFS, "Checking the metadata directory (%s)...", FTI_Conf->metadDir);
             FTI_Print(str, FTI_DBUG);
             if (mkdir(FTI_Conf->metadDir, 0777) == -1) {
                 if (errno != EEXIST) {
@@ -390,7 +390,7 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
             }
 
             // Checking global directory
-            sprintf(str, "Checking the global directory (%s)...", FTI_Conf->glbalDir);
+            snprintf(str,FTI_BUFS,  "Checking the global directory (%s)...", FTI_Conf->glbalDir);
             FTI_Print(str, FTI_DBUG);
             if (mkdir(FTI_Conf->glbalDir, 0777) == -1) {
                 if (errno != EEXIST) {

--- a/src/ftiff.h
+++ b/src/ftiff.h
@@ -40,7 +40,6 @@
 #ifndef _FTIFF_H
 #define _FTIFF_H
 
-#define DECL_MPI_TYPES(TYPE) MPI_Datatype MPI_ ## TYPE ## _RAW, MPI_ ## TYPE
 #define MBR_CNT(TYPE) int TYPE ## _mbrCnt
 #define MBR_BLK_LEN(TYPE) int TYPE ## _mbrBlkLen[]
 #define MBR_TYPES(TYPE) MPI_Datatype TYPE ## _mbrTypes[]

--- a/src/interface.h
+++ b/src/interface.h
@@ -119,7 +119,8 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_Listen(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-        FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
+        FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
+        __attribute__((noreturn));
 
 int FTI_UpdateConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int restart);

--- a/src/meta.c
+++ b/src/meta.c
@@ -64,13 +64,13 @@ int FTI_GetChecksums(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     char mfn[FTI_BUFS]; //Path to the metadata file
     char str[FTI_BUFS]; //For console output
     if (FTI_Exec->ckptLvel == 0) {
-        sprintf(mfn, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, FTI_Topo->groupID);
+        snprintf(mfn, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, FTI_Topo->groupID);
     }
     else {
-        sprintf(mfn, "%s/sector%d-group%d.fti", FTI_Ckpt[FTI_Exec->ckptLvel].metaDir, FTI_Topo->sectorID, FTI_Topo->groupID);
+        snprintf(mfn, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Ckpt[FTI_Exec->ckptLvel].metaDir, FTI_Topo->sectorID, FTI_Topo->groupID);
     }
 
-    sprintf(str, "Getting FTI metadata file (%s)...", mfn);
+    snprintf(str, FTI_BUFS, "Getting FTI metadata file (%s)...", mfn);
     FTI_Print(str, FTI_DBUG);
     if (access(mfn, R_OK) != 0) {
         FTI_Print("FTI metadata file NOT accessible.", FTI_WARN);
@@ -83,17 +83,17 @@ int FTI_GetChecksums(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     }
 
     //Get checksum of checkpoint file
-    sprintf(str, "%d:Ckpt_checksum", FTI_Topo->groupRank);
+    snprintf(str, FTI_BUFS, "%d:Ckpt_checksum", FTI_Topo->groupRank);
     char* checksumTemp = iniparser_getstring(ini, str, "");
     strncpy(checksum, checksumTemp, MD5_DIGEST_STRING_LENGTH);
 
     //Get checksum of partner checkpoint file
-    sprintf(str, "%d:Ckpt_checksum", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
+    snprintf(str, FTI_BUFS, "%d:Ckpt_checksum", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
     checksumTemp = iniparser_getstring(ini, str, "");
     strncpy(ptnerChecksum, checksumTemp, MD5_DIGEST_STRING_LENGTH);
 
     //Get checksum of Reed-Salomon file
-    sprintf(str, "%d:RSed_checksum", FTI_Topo->groupRank);
+    snprintf(str, FTI_BUFS, "%d:RSed_checksum", FTI_Topo->groupRank);
     checksumTemp = iniparser_getstring(ini, str, "");
     strncpy(rsChecksum, checksumTemp, MD5_DIGEST_STRING_LENGTH);
 
@@ -142,7 +142,7 @@ int FTI_WriteRSedChecksum(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec
         return FTI_SCES;
     }
 
-    sprintf(fileName, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, groupID);
+    snprintf(fileName, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, groupID);
     dictionary* ini = iniparser_load(fileName);
     if (ini == NULL) {
         FTI_Print("Temporary metadata file could NOT be parsed", FTI_WARN);
@@ -154,12 +154,12 @@ int FTI_WriteRSedChecksum(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec
     for (i = 0; i < FTI_Topo->groupSize; i++) {
         char buf[FTI_BUFS];
         strncpy(buf, checksums + (i * MD5_DIGEST_STRING_LENGTH), MD5_DIGEST_STRING_LENGTH);
-        sprintf(str, "%d:RSed_checksum", i);
+        snprintf(str, FTI_BUFS, "%d:RSed_checksum", i);
         iniparser_set(ini, str, buf);
     }
     free(checksums);
 
-    sprintf(str, "Recreating metadata file (%s)...", fileName);
+    snprintf(str, FTI_BUFS, "Recreating metadata file (%s)...", fileName);
     FTI_Print(str, FTI_DBUG);
 
     FILE* fd = fopen(fileName, "w");
@@ -211,8 +211,8 @@ int FTI_LoadTmpMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int j, biggestCkptID = 0; //Need to find biggest CkptID
         for (j = 1; j < FTI_Topo->nodeSize; j++) { //all body processes
             char metaFileName[FTI_BUFS], str[FTI_BUFS];
-            sprintf(metaFileName, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, j);
-            sprintf(str, "Getting FTI metadata file (%s)...", metaFileName);
+            snprintf(metaFileName, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, j);
+            snprintf(str, FTI_BUFS, "Getting FTI metadata file (%s)...", metaFileName);
             FTI_Print(str, FTI_DBUG);
             if (access(metaFileName, R_OK) == 0) {
                 dictionary* ini = iniparser_load(metaFileName);
@@ -223,7 +223,7 @@ int FTI_LoadTmpMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 else {
                     FTI_Exec->meta[0].exists[j] = 1;
 
-                    sprintf(str, "%d:Ckpt_file_name", FTI_Topo->groupRank);
+                    snprintf(str, FTI_BUFS, "%d:Ckpt_file_name", FTI_Topo->groupRank);
                     char* ckptFileName = iniparser_getstring(ini, str, NULL);
                     snprintf(&FTI_Exec->meta[0].ckptFile[j * FTI_BUFS], FTI_BUFS, "%s", ckptFileName);
 
@@ -233,17 +233,17 @@ int FTI_LoadTmpMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                         FTI_Exec->ckptID = biggestCkptID;
                     }
 
-                    sprintf(str, "%d:Ckpt_file_size", FTI_Topo->groupRank);
+                    snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", FTI_Topo->groupRank);
                     FTI_Exec->meta[0].fs[j] = iniparser_getlint(ini, str, -1);
 
-                    sprintf(str, "%d:Ckpt_file_size", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
+                    snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
                     FTI_Exec->meta[0].pfs[j] = iniparser_getlint(ini, str, -1);
 
                     FTI_Exec->meta[0].maxFs[j] = iniparser_getlint(ini, "0:Ckpt_file_maxs", -1);
 
                     int k;
                     for (k = 0; k < FTI_BUFS; k++) {
-                        sprintf(str, "%d:Var%d_id", FTI_Topo->groupRank, k);
+                        snprintf(str, FTI_BUFS, "%d:Var%d_id", FTI_Topo->groupRank, k);
                         int id = iniparser_getint(ini, str, -1);
                         if (id == -1) {
                             //No more variables
@@ -252,7 +252,7 @@ int FTI_LoadTmpMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                         //Variable exists
                         FTI_Exec->meta[0].varID[j * FTI_BUFS + k] = id;
 
-                        sprintf(str, "%d:Var%d_size", FTI_Topo->groupRank, k);
+                        snprintf(str, FTI_BUFS, "%d:Var%d_size", FTI_Topo->groupRank, k);
                         FTI_Exec->meta[0].varSize[j * FTI_BUFS + k] = iniparser_getlint(ini, str, -1);
                     }
                     //Save number of variables in metadata
@@ -262,7 +262,7 @@ int FTI_LoadTmpMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 }
             }
             else {
-                sprintf(str, "Temporary metadata do not exist for node process %d.", j);
+                snprintf(str, FTI_BUFS, "Temporary metadata do not exist for node process %d.", j);
                 FTI_Print(str, FTI_WARN);
                 return FTI_NSCS;
             }
@@ -296,11 +296,11 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         for (i = 0; i < 5; i++) { //for each level
             char metaFileName[FTI_BUFS], str[FTI_BUFS];
             if (i == 0) {
-                sprintf(metaFileName, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, FTI_Topo->groupID);
+                snprintf(metaFileName, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, FTI_Topo->groupID);
             } else {
-                sprintf(metaFileName, "%s/sector%d-group%d.fti", FTI_Ckpt[i].metaDir, FTI_Topo->sectorID, FTI_Topo->groupID);
+                snprintf(metaFileName, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Ckpt[i].metaDir, FTI_Topo->sectorID, FTI_Topo->groupID);
             }
-            sprintf(str, "Getting FTI metadata file (%s)...", metaFileName);
+            snprintf(str, FTI_BUFS, "Getting FTI metadata file (%s)...", metaFileName);
             FTI_Print(str, FTI_DBUG);
             if (access(metaFileName, R_OK) == 0) {
                 dictionary* ini = iniparser_load(metaFileName);
@@ -309,25 +309,25 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     return FTI_NSCS;
                 }
                 else {
-                    sprintf(str, "Meta for level %d exists.", i);
+                    snprintf(str, FTI_BUFS, "Meta for level %d exists.", i);
                     FTI_Print(str, FTI_DBUG);
                     FTI_Exec->meta[i].exists[0] = 1;
 
-                    sprintf(str, "%d:Ckpt_file_name", FTI_Topo->groupRank);
+                    snprintf(str, FTI_BUFS, "%d:Ckpt_file_name", FTI_Topo->groupRank);
                     char* ckptFileName = iniparser_getstring(ini, str, NULL);
                     snprintf(FTI_Exec->meta[i].ckptFile, FTI_BUFS, "%s", ckptFileName);
 
-                    sprintf(str, "%d:Ckpt_file_size", FTI_Topo->groupRank);
+                    snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", FTI_Topo->groupRank);
                     FTI_Exec->meta[i].fs[0] = iniparser_getlint(ini, str, -1);
 
-                    sprintf(str, "%d:Ckpt_file_size", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
+                    snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
                     FTI_Exec->meta[i].pfs[0] = iniparser_getlint(ini, str, -1);
 
                     FTI_Exec->meta[i].maxFs[0] = iniparser_getlint(ini, "0:Ckpt_file_maxs", -1);
 
                     int k;
                     for (k = 0; k < FTI_BUFS; k++) {
-                        sprintf(str, "%d:Var%d_id", FTI_Topo->groupRank, k);
+                        snprintf(str, FTI_BUFS, "%d:Var%d_id", FTI_Topo->groupRank, k);
                         int id = iniparser_getint(ini, str, -1);
                         if (id == -1) {
                             //No more variables
@@ -336,7 +336,7 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                         //Variable exists
                         FTI_Exec->meta[i].varID[k] = id;
 
-                        sprintf(str, "%d:Var%d_size", FTI_Topo->groupRank, k);
+                        snprintf(str, FTI_BUFS, "%d:Var%d_size", FTI_Topo->groupRank, k);
                         FTI_Exec->meta[i].varSize[k] = iniparser_getlint(ini, str, -1);
                     }
                     //Save number of variables in metadata
@@ -356,11 +356,11 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 dictionary* ini;
                 char metaFileName[FTI_BUFS], str[FTI_BUFS];
                 if (i == 0) {
-                    sprintf(metaFileName, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, j);
+                    snprintf(metaFileName, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, j);
                 } else {
-                    sprintf(metaFileName, "%s/sector%d-group%d.fti", FTI_Ckpt[i].metaDir, FTI_Topo->sectorID, j);
+                    snprintf(metaFileName, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Ckpt[i].metaDir, FTI_Topo->sectorID, j);
                 }
-                sprintf(str, "Getting FTI metadata file (%s)...", metaFileName);
+                snprintf(str, FTI_BUFS, "Getting FTI metadata file (%s)...", metaFileName);
                 FTI_Print(str, FTI_DBUG);
                 if (access(metaFileName, R_OK) == 0) {
                     ini = iniparser_load(metaFileName);
@@ -369,11 +369,11 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                         return FTI_NSCS;
                     }
                     else {
-                        sprintf(str, "Meta for level %d exists.", i);
+                        snprintf(str, FTI_BUFS, "Meta for level %d exists.", i);
                         FTI_Print(str, FTI_DBUG);
                         FTI_Exec->meta[i].exists[j] = 1;
 
-                        sprintf(str, "%d:Ckpt_file_name", FTI_Topo->groupRank);
+                        snprintf(str, FTI_BUFS, "%d:Ckpt_file_name", FTI_Topo->groupRank);
                         char* ckptFileName = iniparser_getstring(ini, str, NULL);
                         snprintf(&FTI_Exec->meta[i].ckptFile[j * FTI_BUFS], FTI_BUFS, "%s", ckptFileName);
 
@@ -383,16 +383,16 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                             FTI_Exec->ckptID = biggestCkptID;
                         }
 
-                        sprintf(str, "%d:Ckpt_file_size", FTI_Topo->groupRank);
+                        snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", FTI_Topo->groupRank);
                         FTI_Exec->meta[i].fs[j] = iniparser_getlint(ini, str, -1);
 
-                        sprintf(str, "%d:Ckpt_file_size", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
+                        snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", (FTI_Topo->groupRank + FTI_Topo->groupSize - 1) % FTI_Topo->groupSize);
                         FTI_Exec->meta[i].pfs[j] = iniparser_getlint(ini, str, -1);
 
                         FTI_Exec->meta[i].maxFs[j] = iniparser_getlint(ini, "0:Ckpt_file_maxs", -1);
                         int k;
                         for (k = 0; k < FTI_BUFS; k++) {
-                            sprintf(str, "%d:Var%d_id", FTI_Topo->groupRank, k);
+                            snprintf(str, FTI_BUFS, "%d:Var%d_id", FTI_Topo->groupRank, k);
                             int id = iniparser_getint(ini, str, -1);
                             if (id == -1) {
                                 //No more variables
@@ -401,7 +401,7 @@ int FTI_LoadMeta(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                             //Variable exists
                             FTI_Exec->meta[i].varID[j * FTI_BUFS + k] = id;
 
-                            sprintf(str, "%d:Var%d_size", FTI_Topo->groupRank, k);
+                            snprintf(str, FTI_BUFS, "%d:Var%d_size", FTI_Topo->groupRank, k);
                             FTI_Exec->meta[i].varSize[j * FTI_BUFS + k] = iniparser_getlint(ini, str, -1);
                         }
                         //Save number of variables in metadata
@@ -444,7 +444,7 @@ int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
 	char str[FTI_BUFS], buf[FTI_BUFS];
     snprintf(buf, FTI_BUFS, "%s/Topology.fti", FTI_Conf->metadDir);
-    sprintf(str, "Temporary load of topology file (%s)...", buf);
+    snprintf(str, FTI_BUFS, "Temporary load of topology file (%s)...", buf);
     FTI_Print(str, FTI_DBUG);
 
     // To bypass iniparser bug while empty dict.
@@ -458,29 +458,29 @@ int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     int i;
     for (i = 0; i < FTI_Topo->groupSize; i++) {
         strncpy(buf, fnl + (i * FTI_BUFS), FTI_BUFS - 1);
-        sprintf(str, "%d", i);
+        snprintf(str, FTI_BUFS, "%d", i);
         iniparser_set(ini, str, NULL);
-        sprintf(str, "%d:Ckpt_file_name", i);
+        snprintf(str, FTI_BUFS, "%d:Ckpt_file_name", i);
         iniparser_set(ini, str, buf);
-        sprintf(str, "%d:Ckpt_file_size", i);
-        sprintf(buf, "%lu", fs[i]);
+        snprintf(str, FTI_BUFS, "%d:Ckpt_file_size", i);
+        snprintf(buf, FTI_BUFS, "%lu", fs[i]);
         iniparser_set(ini, str, buf);
-        sprintf(str, "%d:Ckpt_file_maxs", i);
-        sprintf(buf, "%lu", mfs);
+        snprintf(str, FTI_BUFS, "%d:Ckpt_file_maxs", i);
+        snprintf(buf, FTI_BUFS, "%lu", mfs);
         iniparser_set(ini, str, buf);
         strncpy(buf, checksums + (i * MD5_DIGEST_STRING_LENGTH), MD5_DIGEST_STRING_LENGTH);
-        sprintf(str, "%d:Ckpt_checksum", i);
+        snprintf(str, FTI_BUFS, "%d:Ckpt_checksum", i);
         iniparser_set(ini, str, buf);
         int j;
         for (j = 0; j < FTI_Exec->nbVar; j++) {
             //Save id of variable
-            sprintf(str, "%d:Var%d_id", i, j);
-            sprintf(buf, "%d", allVarIDs[i * FTI_Exec->nbVar + j]);
+            snprintf(str, FTI_BUFS, "%d:Var%d_id", i, j);
+            snprintf(buf, FTI_BUFS, "%d", allVarIDs[i * FTI_Exec->nbVar + j]);
             iniparser_set(ini, str, buf);
 
             //Save size of variable
-            sprintf(str, "%d:Var%d_size", i, j);
-            sprintf(buf, "%ld", allVarSizes[i * FTI_Exec->nbVar + j]);
+            snprintf(str, FTI_BUFS, "%d:Var%d_size", i, j);
+            snprintf(buf, FTI_BUFS, "%ld", allVarSizes[i * FTI_Exec->nbVar + j]);
             iniparser_set(ini, str, buf);
         }
     }
@@ -493,14 +493,14 @@ int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         }
     }
 
-    sprintf(buf, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, FTI_Topo->groupID);
+    snprintf(buf, FTI_BUFS, "%s/sector%d-group%d.fti", FTI_Conf->mTmpDir, FTI_Topo->sectorID, FTI_Topo->groupID);
     if (remove(buf) == -1) {
         if (errno != ENOENT) {
             FTI_Print("Cannot remove sector-group.fti", FTI_EROR);
         }
     }
 
-    sprintf(str, "Creating metadata file (%s)...", buf);
+    snprintf(str, FTI_BUFS, "Creating metadata file (%s)...", buf);
     FTI_Print(str, FTI_DBUG);
 
     FILE* fd = fopen(buf, "w");
@@ -556,10 +556,10 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 #ifdef ENABLE_HDF5
     char fn[FTI_BUFS];
     if (FTI_Exec->ckptLvel == 4 && FTI_Ckpt[4].isInline) { //If inline L4 save directly to global directory
-        sprintf(fn, "%s/%s", FTI_Conf->gTmpDir, FTI_Exec->meta[0].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, FTI_Exec->meta[0].ckptFile);
     }
     else {
-        sprintf(fn, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->meta[0].ckptFile);
+        snprintf(fn, FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, FTI_Exec->meta[0].ckptFile);
     }
     if (access(fn, F_OK) == 0) {
         struct stat fileStatus;
@@ -568,13 +568,13 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         }
         else {
             char str[FTI_BUFS];
-            sprintf(str, "FTI couldn't get ckpt file size. (%s)", fn);
+            snprintf(str, FTI_BUFS, "FTI couldn't get ckpt file size. (%s)", fn);
             FTI_Print(str, FTI_WARN);
         }
     }
     else {
         char str[FTI_BUFS];
-        sprintf(str, "FTI couldn't acces file ckpt file. (%s)", fn);
+        snprintf(str, FTI_BUFS, "FTI couldn't acces file ckpt file. (%s)", fn);
         FTI_Print(str, FTI_WARN);
     }
 #endif
@@ -598,14 +598,14 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     }
     FTI_Exec->meta[0].maxFs[0] = mfs;
     char str[FTI_BUFS]; //For console output
-    sprintf(str, "Max. file size in group %lu.", mfs);
+    snprintf(str, FTI_BUFS, "Max. file size in group %lu.", mfs);
     FTI_Print(str, FTI_DBUG);
 
     char* ckptFileNames;
     if (FTI_Topo->groupRank == 0) {
         ckptFileNames = talloc(char, FTI_Topo->groupSize * FTI_BUFS);
     }
-    strcpy(str, FTI_Exec->meta[0].ckptFile); // Gather all the file names
+    strncpy(str, FTI_Exec->meta[0].ckptFile, FTI_BUFS); // Gather all the file names
     MPI_Gather(str, FTI_BUFS, MPI_CHAR, ckptFileNames, FTI_BUFS, MPI_CHAR, 0, FTI_Exec->groupComm);
 
     char checksum[MD5_DIGEST_STRING_LENGTH];
@@ -663,7 +663,7 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FTI_Exec->meta[FTI_Exec->ckptLvel].fs[0] = FTI_Exec->meta[0].fs[0];
     FTI_Exec->meta[FTI_Exec->ckptLvel].pfs[0] = FTI_Exec->meta[0].pfs[0];
     FTI_Exec->meta[FTI_Exec->ckptLvel].maxFs[0] = FTI_Exec->meta[0].maxFs[0];
-    strcpy(FTI_Exec->meta[FTI_Exec->ckptLvel].ckptFile, FTI_Exec->meta[0].ckptFile);
+    strncpy(FTI_Exec->meta[FTI_Exec->ckptLvel].ckptFile, FTI_Exec->meta[0].ckptFile, FTI_BUFS);
     for (i = 0; i < FTI_Exec->nbVar; i++) {
         FTI_Exec->meta[0].varID[i] = FTI_Data[i].id;
         FTI_Exec->meta[0].varSize[i] = FTI_Data[i].size;

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -77,14 +77,14 @@ int FTI_SendCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_ch
         int destination, int postFlag)
 {
     char lfn[FTI_BUFS], str[FTI_BUFS];
-    sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[postFlag * FTI_BUFS]);
+    snprintf(lfn, FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[postFlag * FTI_BUFS]);
 
     //PostFlag is set to 0 if Post-processing is inline and set to processes nodeID if Post-processing done by head
     if (postFlag) {
-        sprintf(str, "L2 trying to access process's %d ckpt. file (%s).", postFlag, lfn);
+        snprintf(str, FTI_BUFS, "L2 trying to access process's %d ckpt. file (%s).", postFlag, lfn);
     }
     else {
-        sprintf(str, "L2 trying to access local ckpt. file (%s).", lfn);
+        snprintf(str, FTI_BUFS, "L2 trying to access local ckpt. file (%s).", lfn);
     }
     FTI_Print(str, FTI_DBUG);
 
@@ -142,8 +142,8 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
     sscanf(&FTI_Exec->meta[0].ckptFile[postFlag * FTI_BUFS], "Ckpt%d-Rank%d.fti", &ckptID, &rank);
 
     char pfn[FTI_BUFS], str[FTI_BUFS];
-    sprintf(pfn, "%s/Ckpt%d-Pcof%d.fti", FTI_Conf->lTmpDir, ckptID, rank);
-    sprintf(str, "L2 trying to access Ptner file (%s).", pfn);
+    snprintf(pfn, FTI_BUFS, "%s/Ckpt%d-Pcof%d.fti", FTI_Conf->lTmpDir, ckptID, rank);
+    snprintf(str, FTI_BUFS, "L2 trying to access Ptner file (%s).", pfn);
     FTI_Print(str, FTI_DBUG);
 
     FILE* pfd = fopen(pfn, "wb");
@@ -279,11 +279,11 @@ int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         sscanf(&FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS], "Ckpt%d-Rank%d.fti", &ckptID, &rank);
         char lfn[FTI_BUFS], efn[FTI_BUFS];
 
-        sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
-        sprintf(efn, "%s/Ckpt%d-RSed%d.fti", FTI_Conf->lTmpDir, ckptID, rank);
+        snprintf(lfn, FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+        snprintf(efn, FTI_BUFS, "%s/Ckpt%d-RSed%d.fti", FTI_Conf->lTmpDir, ckptID, rank);
 
         char str[FTI_BUFS];
-        sprintf(str, "L3 trying to access local ckpt. file (%s).", lfn);
+        snprintf(str, FTI_BUFS, "L3 trying to access local ckpt. file (%s).", lfn);
         FTI_Print(str, FTI_DBUG);
 
         //all files in group must have the same size
@@ -439,7 +439,7 @@ int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             FTIFFMeta->ptFs = -1;
             FTIFFMeta->maxFs = maxFs;
             FTIFFMeta->ckptSize = FTI_Exec->meta[0].fs[proc];
-            strcpy(FTIFFMeta->checksum, checksum);
+            strncpy(FTIFFMeta->checksum, checksum, MD5_DIGEST_STRING_LENGTH);
 
             // get hash of meta data
             FTIFF_GetHashMetaInfo( FTIFFMeta->myHash, FTIFFMeta );
@@ -500,7 +500,7 @@ int FTI_Flush(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
      **/
 
     char str[FTI_BUFS];
-    sprintf(str, "Starting checkpoint post-processing L4 for level %d", level);
+    snprintf(str, FTI_BUFS, "Starting checkpoint post-processing L4 for level %d", level);
     FTI_Print(str, FTI_DBUG);
     // create global temp directory
     if (mkdir(FTI_Conf->gTmpDir, 0777) == -1) {
@@ -563,11 +563,11 @@ int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     for (proc = startProc; proc < endProc; proc++) {
         char str[FTI_BUFS];
-        sprintf(str, "Post-processing for proc %d started.", proc);
+        snprintf(str, FTI_BUFS, "Post-processing for proc %d started.", proc);
         FTI_Print(str, FTI_DBUG);
         char lfn[FTI_BUFS], gfn[FTI_BUFS];
-        sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
-        sprintf(str, "Global temporary file name for proc %d: %s", proc, gfn);
+        snprintf(gfn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+        snprintf(str, FTI_BUFS, "Global temporary file name for proc %d: %s", proc, gfn);
         FTI_Print(str, FTI_DBUG);
         FILE* gfd = fopen(gfn, "wb");
 
@@ -577,12 +577,12 @@ int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         }
 
         if (level == 0) {
-            sprintf(lfn, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+            snprintf(lfn, FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
         }
         else {
-            sprintf(lfn, "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+            snprintf(lfn, FTI_BUFS, "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
         }
-        sprintf(str, "Local file name for proc %d: %s", proc, lfn);
+        snprintf(str, FTI_BUFS, "Local file name for proc %d: %s", proc, lfn);
         FTI_Print(str, FTI_DBUG);
         // Open local file
         FILE* lfd = fopen(lfn, "rb");
@@ -595,7 +595,7 @@ int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         char *readData = talloc(char, FTI_Conf->transferSize);
         long bSize = FTI_Conf->transferSize;
         long fs = FTI_Exec->meta[level].fs[proc];
-        sprintf(str, "Local file size for proc %d: %ld", proc, fs);
+        snprintf(str, FTI_BUFS, "Local file size for proc %d: %ld", proc, fs);
         FTI_Print(str, FTI_DBUG);
         long pos = 0;
         // Checkpoint files exchange
@@ -658,9 +658,9 @@ int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     // open parallel file (collective call)
     MPI_File pfh; // MPI-IO file handle
-    char gfn[FTI_BUFS], lfn[FTI_BUFS], str[FTI_BUFS], ckptFile[FTI_BUFS];
+    char gfn[FTI_BUFS], str[FTI_BUFS], ckptFile[FTI_BUFS];
     snprintf(ckptFile, FTI_BUFS, "Ckpt%d-mpiio.fti", FTI_Exec->ckptID);
-    sprintf(gfn, "%s/%s", FTI_Conf->gTmpDir, ckptFile);
+    snprintf(gfn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, ckptFile);
 #ifdef LUSTRE
     if (FTI_Topo->splitRank == 0) {
         res = llapi_file_create(gfn, FTI_Conf->stripeUnit, FTI_Conf->stripeOffset, FTI_Conf->stripeFactor, 0);
@@ -668,7 +668,7 @@ int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             char error_msg[FTI_BUFS];
             error_msg[0] = 0;
             strerror_r(-res, error_msg, FTI_BUFS);
-            sprintf(str, "[Lustre] %s.", error_msg);
+            snprintf(str, FTI_BUFS, "[Lustre] %s.", error_msg);
             FTI_Print(str, FTI_WARN);
         } else {
             snprintf(str, FTI_BUFS, "[LUSTRE] file:%s striping_unit:%i striping_factor:%i striping_offset:%i",
@@ -704,10 +704,10 @@ int FTI_FlushMPI(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     int* splitRanks = talloc(int, endProc); //rank of process in FTI_COMM_WORLD
     for (proc = startProc; proc < endProc; proc++) {
         if (level == 0) {
-            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+            snprintf(&localFileNames[proc * FTI_BUFS], FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
         }
         else {
-            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+            snprintf(&localFileNames[proc * FTI_BUFS], FTI_BUFS, "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
         }
         if (FTI_Topo->amIaHead) {
             splitRanks[proc] = (FTI_Topo->nodeSize - 1) * FTI_Topo->nodeID + proc - 1; //determine process splitRank if head
@@ -828,10 +828,10 @@ int FTI_FlushSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     for (proc = startProc; proc < endProc; proc++) {
         // Open local file case 0:
         if (level == 0) {
-            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
+            snprintf(&localFileNames[proc * FTI_BUFS], FTI_BUFS, "%s/%s", FTI_Conf->lTmpDir, &FTI_Exec->meta[0].ckptFile[proc * FTI_BUFS]);
         }
         else {
-            sprintf(&localFileNames[proc * FTI_BUFS], "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
+            snprintf(&localFileNames[proc * FTI_BUFS], FTI_BUFS, "%s/%s", FTI_Ckpt[level].dir, &FTI_Exec->meta[level].ckptFile[proc * FTI_BUFS]);
         }
         if (FTI_Topo->amIaHead) {
             splitRanks[proc - startProc] = (FTI_Topo->nodeSize - 1) * FTI_Topo->nodeID + proc - 1; //[proc - startProc] to get index from 0
@@ -846,7 +846,7 @@ int FTI_FlushSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     char fn[FTI_BUFS], str[FTI_BUFS];
     sscanf(&FTI_Exec->meta[level].ckptFile[0], "Ckpt%d-Rank%d.fti", &ckptID, &rank);
     snprintf(str, FTI_BUFS, "Ckpt%d-sionlib.fti", ckptID);
-    sprintf(fn, "%s/%s", FTI_Conf->gTmpDir, str);
+    snprintf(fn, FTI_BUFS, "%s/%s", FTI_Conf->gTmpDir, str);
 
     int numFiles = 1;
     int nlocaltasks = nbProc;
@@ -891,7 +891,7 @@ int FTI_FlushSionlib(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int res = sion_seek(sid, splitRanks[proc - startProc], SION_CURRENT_BLK, SION_CURRENT_POS);
         if (res != SION_SUCCESS) {
             errno = 0;
-            sprintf(str, "SIONlib: unable to set file pointer");
+            snprintf(str, FTI_BUFS, "SIONlib: unable to set file pointer");
             FTI_Print(str, FTI_EROR);
             free(localFileNames);
             free(splitRanks);

--- a/src/recover.c
+++ b/src/recover.c
@@ -107,44 +107,44 @@ int FTI_CheckErasures(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     long pfs = FTI_Exec->meta[level].pfs[0];
     long maxFs = FTI_Exec->meta[level].maxFs[0];
     char ckptFile[FTI_BUFS];
-    strcpy(ckptFile, FTI_Exec->meta[level].ckptFile);
+    strncpy(ckptFile, FTI_Exec->meta[level].ckptFile, FTI_BUFS);
 
     char checksum[MD5_DIGEST_STRING_LENGTH], ptnerChecksum[MD5_DIGEST_STRING_LENGTH], rsChecksum[MD5_DIGEST_STRING_LENGTH];
     FTI_GetChecksums(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, checksum, ptnerChecksum, rsChecksum);
     char str[FTI_BUFS];
-    sprintf(str, "Checking file %s and its erasures.", ckptFile);
+    snprintf(str, FTI_BUFS, "Checking file %s and its erasures.", ckptFile);
     FTI_Print(str, FTI_DBUG);
     char fn[FTI_BUFS]; //Path to the checkpoint/partner file name
     int buf;
     int ckptID, rank; //Variables for proper partner file name
     switch (level) {
         case 1:
-            sprintf(fn, "%s/%s", FTI_Ckpt[1].dir, ckptFile);
+            snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[1].dir, ckptFile);
             buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
             break;
         case 2:
-            sprintf(fn, "%s/%s", FTI_Ckpt[2].dir, ckptFile);
+            snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[2].dir, ckptFile);
             buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
 
             sscanf(ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank);
-            sprintf(fn, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, ckptID, rank);
+            snprintf(fn, FTI_BUFS, "%s/Ckpt%d-Pcof%d.fti", FTI_Ckpt[2].dir, ckptID, rank);
             buf = FTI_CheckFile(fn, pfs, ptnerChecksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased + FTI_Topo->groupSize, 1, MPI_INT, FTI_Exec->groupComm);
             break;
         case 3:
-            sprintf(fn, "%s/%s", FTI_Ckpt[3].dir, ckptFile);
+            snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[3].dir, ckptFile);
             buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
 
             sscanf(ckptFile, "Ckpt%d-Rank%d.fti", &ckptID, &rank);
-            sprintf(fn, "%s/Ckpt%d-RSed%d.fti", FTI_Ckpt[3].dir, ckptID, rank);
+            snprintf(fn, FTI_BUFS, "%s/Ckpt%d-RSed%d.fti", FTI_Ckpt[3].dir, ckptID, rank);
             buf = FTI_CheckFile(fn, maxFs, rsChecksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased + FTI_Topo->groupSize, 1, MPI_INT, FTI_Exec->groupComm);
             break;
         case 4:
-            sprintf(fn, "%s/%s", FTI_Ckpt[4].dir, ckptFile);
+            snprintf(fn, FTI_BUFS, "%s/%s", FTI_Ckpt[4].dir, ckptFile);
             buf = FTI_CheckFile(fn, fs, checksum);
             MPI_Allgather(&buf, 1, MPI_INT, erased, 1, MPI_INT, FTI_Exec->groupComm);
             break;
@@ -185,7 +185,7 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                 FTI_Exec->ckptID = ckptID;
 
                 char str[FTI_BUFS];
-                sprintf(str, "Trying recovery with Ckpt. %d at level %d.", ckptID, level);
+                snprintf(str, FTI_BUFS, "Trying recovery with Ckpt. %d at level %d.", ckptID, level);
                 FTI_Print(str, FTI_DBUG);
 
                 int res;
@@ -217,7 +217,7 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                         ckptID = FTI_Exec->ckptID;
                     }
 
-                    sprintf(str, "Recovering successfully from level %d with Ckpt. %d.", level, ckptID);
+                    snprintf(str, FTI_BUFS, "Recovering successfully from level %d with Ckpt. %d.", level, ckptID);
                     FTI_Print(str, FTI_INFO);
 
                     //Update ckptID and ckptLevel
@@ -226,7 +226,7 @@ int FTI_RecoverFiles(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     return FTI_SCES; //Recovered successfully
                 }
                 else {
-                    sprintf(str, "Recover failed from level %d with Ckpt. %d.", level, ckptID);
+                    snprintf(str, FTI_BUFS, "Recover failed from level %d with Ckpt. %d.", level, ckptID);
                     FTI_Print(str, FTI_INFO);
                 }
             }

--- a/src/topo.c
+++ b/src/topo.c
@@ -55,7 +55,7 @@
 int FTI_SaveTopo(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo, char* nameList)
 {
     char str[FTI_BUFS];
-    sprintf(str, "Trying to load configuration file (%s) to create topology.", FTI_Conf->cfgFile);
+    snprintf(str, FTI_BUFS, "Trying to load configuration file (%s) to create topology.", FTI_Conf->cfgFile);
     FTI_Print(str, FTI_DBUG);
 
     dictionary* ini = iniparser_load(FTI_Conf->cfgFile);
@@ -72,7 +72,7 @@ int FTI_SaveTopo(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo, char* na
     for (i = 0; i < FTI_Topo->nbNodes; i++) {
         char mfn[FTI_BUFS];
         strncpy(mfn, nameList + (i * FTI_BUFS), FTI_BUFS - 1);
-        sprintf(str, "topology:%d", i);
+        snprintf(str, FTI_BUFS, "topology:%d", i);
         iniparser_set(ini, str, mfn);
     }
 
@@ -82,8 +82,8 @@ int FTI_SaveTopo(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo, char* na
     iniparser_unset(ini, "advanced");
 
     char mfn[FTI_BUFS];
-    sprintf(mfn, "%s/Topology.fti", FTI_Conf->metadDir);
-    sprintf(str, "Creating topology file (%s)...", mfn);
+    snprintf(mfn, FTI_BUFS, "%s/Topology.fti", FTI_Conf->metadDir);
+    snprintf(str, FTI_BUFS, "Creating topology file (%s)...", mfn);
     FTI_Print(str, FTI_DBUG);
 
     FILE* fd = fopen(mfn, "w");
@@ -139,8 +139,8 @@ int FTI_ReorderNodes(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
     }
 
     char mfn[FTI_BUFS], str[FTI_BUFS];
-    sprintf(mfn, "%s/Topology.fti", FTI_Conf->metadDir);
-    sprintf(str, "Loading FTI topology file (%s) to reorder nodes...", mfn);
+    snprintf(mfn, FTI_BUFS, "%s/Topology.fti", FTI_Conf->metadDir);
+    snprintf(str, FTI_BUFS, "Loading FTI topology file (%s) to reorder nodes...", mfn);
     FTI_Print(str, FTI_DBUG);
 
     // Checking that the topology file exist
@@ -168,7 +168,7 @@ int FTI_ReorderNodes(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
 
     // Get the old order of nodes
     for (i = 0; i < FTI_Topo->nbNodes; i++) {
-        sprintf(str, "Topology:%d", i);
+        snprintf(str, FTI_BUFS, "Topology:%d", i);
         char* tmp = iniparser_getstring(ini, str, NULL);
         snprintf(str, FTI_BUFS, "%s", tmp);
 
@@ -286,7 +286,7 @@ int FTI_BuildNodeList(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     for (i = 0; i < FTI_Topo->nbProc; i++) { // Checking that all nodes have nodeSize processes
         if (nodeList[i] == -1) {
             char str[FTI_BUFS];
-            sprintf(str, "Node %d has no %d processes", i / FTI_Topo->nodeSize, FTI_Topo->nodeSize);
+            snprintf(str, FTI_BUFS, "Node %d has no %d processes", i / FTI_Topo->nodeSize, FTI_Topo->nodeSize);
             FTI_Print(str, FTI_WARN);
             free(lhn);
             return FTI_NSCS;

--- a/test/cmake/minimal.c
+++ b/test/cmake/minimal.c
@@ -1,0 +1,1 @@
+int main() {return 0;}


### PR DESCRIPTION
all local tests successful.

>  fixes also a bug observed in FTI used in C++ application iPic3D. The
>  bug was related to a memory overflow happening durin strcpy.
>  strcpy -> strncpy solved this issue.