### PR TITLE
Hdf5 save types

### DIFF
--- a/include/fti.h
+++ b/include/fti.h
@@ -211,7 +211,7 @@ extern "C" {
      *  This type simplify creating complex datatypes.
      */
     typedef struct FTIT_typeField {
-        FTIT_type*          type;                   /**< Field FTI type.                    */
+        int                 typeID;                 /**< FTI type ID of the field.          */
         int                 offset;                 /**< Offset of the field in structure.  */
         int                 rank;                   /**< Field rank (max. 32)               */
         int                 dimLength[32];          /**< Lenght of each dimention           */
@@ -224,10 +224,9 @@ extern "C" {
      *  This type allows creating complex datatypes.
      */
     typedef struct FTIT_complexType {
-        FTIT_typeField      field[FTI_BUFS];        /**< Fields of the complex type.        */
         char                name[FTI_BUFS];         /**< Name of the complex type.          */
         int                 length;                 /**< Number of types in complex type.   */
-        size_t              size;                   /**< Size of the complex type.          */
+        FTIT_typeField      field[FTI_BUFS];        /**< Fields of the complex type.        */
     } FTIT_complexType;
 
     /** @typedef    FTIT_dataset
@@ -300,9 +299,10 @@ extern "C" {
         FTIFF_db         *firstdb;          /**< Pointer to first datablock     */
         FTIFF_db         *lastdb;           /**< Pointer to first datablock     */
         FTIFF_metaInfo  FTIFFMeta;          /**< File meta data for FTI-FF      */
+        FTIT_type**     FTI_Type;           /**< Pointer to FTI_Types           */
+        FTIT_H5Group    H5RootGroup;        /**< HDF5 root group.               */
         MPI_Comm        globalComm;         /**< Global communicator.           */
         MPI_Comm        groupComm;          /**< Group communicator.            */
-        FTIT_H5Group    H5RootGroup;        /** HDF5 root group.                 */
     } FTIT_execution;
 
     /** @typedef    FTIT_configuration

--- a/include/fti.h
+++ b/include/fti.h
@@ -182,11 +182,12 @@ extern "C" {
     typedef struct FTIT_H5Group FTIT_H5Group;
 
     typedef struct FTIT_H5Group {
-        char                name[FTI_BUFS];     /**< Name of the group.             */
-        int                 childrenNo;         /**< Number of children             */
-        FTIT_H5Group*       children[FTI_BUFS]; /**< Pointers to the children groups*/
+        int                 id;                     /**< ID of the group.               */
+        char                name[FTI_BUFS];         /**< Name of the group.             */
+        int                 childrenNo;             /**< Number of children             */
+        int                 childrenID[FTI_BUFS];   /**< IDs of the children groups     */
 #ifdef ENABLE_HDF5
-        hid_t               h5groupID;            /**< Group hid_t.                   */
+        hid_t               h5groupID;              /**< Group hid_t.                   */
 #endif
     } FTIT_H5Group;
 
@@ -293,6 +294,7 @@ extern "C" {
         unsigned int    nbVar;              /**< Number of protected variables. */
         unsigned int    nbVarStored;        /**< Nr. prot. var. stored in file  */
         unsigned int    nbType;             /**< Number of data types.          */
+        int             nbGroup;            /**< Number of protected groups.    */
         int             metaAlloc;          /**< True if meta allocated.        */
         int             initSCES;           /**< True if FTI initialized.       */
         FTIT_metadata   meta[5];            /**< Metadata for each ckpt level   */
@@ -300,7 +302,7 @@ extern "C" {
         FTIFF_db         *lastdb;           /**< Pointer to first datablock     */
         FTIFF_metaInfo  FTIFFMeta;          /**< File meta data for FTI-FF      */
         FTIT_type**     FTI_Type;           /**< Pointer to FTI_Types           */
-        FTIT_H5Group    H5RootGroup;        /**< HDF5 root group.               */
+        FTIT_H5Group**  H5groups;           /**< HDF5 root group.               */
         MPI_Comm        globalComm;         /**< Global communicator.           */
         MPI_Comm        groupComm;          /**< Group communicator.            */
     } FTIT_execution;
@@ -433,6 +435,7 @@ extern "C" {
     void FTI_AddComplexField(FTIT_complexType* typeDefinition, FTIT_type* ftiType,
                                 size_t offset, int rank, int* dimLength, int id, char* name);
     int FTI_InitGroup(FTIT_H5Group* h5group, char* name, FTIT_H5Group* parent);
+    int FTI_RenameGroup(FTIT_H5Group* h5group, char* name);
     int FTI_Protect(int id, void* ptr, long count, FTIT_type type);
     int FTI_DefineDataset(int id, int rank, int* dimLength, char* name, FTIT_H5Group* h5group);
     long FTI_GetStoredSize(int id);

--- a/src/api.c
+++ b/src/api.c
@@ -422,12 +422,13 @@ int FTI_InitGroup(FTIT_H5Group* h5group, char* name, FTIT_H5Group* parent)
         //child of root
         parent = FTI_Exec.H5groups[0];
     }
+    FTIT_H5Group* parentInArray = FTI_Exec.H5groups[parent->id];
     //check if this parent has that child
     int i;
-    for (i = 0; i < parent->childrenNo; i++) {
-        if (strcmp(FTI_Exec.H5groups[parent->childrenID[i]]->name, name) == 0) {
+    for (i = 0; i < parentInArray->childrenNo; i++) {
+        if (strcmp(FTI_Exec.H5groups[parentInArray->childrenID[i]]->name, name) == 0) {
             char str[FTI_BUFS];
-            sprintf(str, "Group %s already has the %s child.", parent->name, name);
+            sprintf(str, "Group %s already has the %s child.", parentInArray->name, name);
             return FTI_NSCS;
         }
     }

--- a/src/api.c
+++ b/src/api.c
@@ -118,14 +118,7 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
     if (res == FTI_NSCS) {
         return FTI_NSCS;
     }
-    if (FTI_Conf.ioMode == FTI_IO_HDF5) {
-        FTI_Exec.H5groups = malloc(sizeof(FTIT_H5Group*) * FTI_BUFS);
-        FTI_Exec.H5groups[0] = malloc(sizeof(FTIT_H5Group));
-        FTI_Exec.H5groups[0]->id = 0;
-        FTI_Exec.H5groups[0]->childrenNo = 0;
-        sprintf(FTI_Exec.H5groups[0]->name, "/");
-        FTI_Exec.nbGroup = 1;
-    }
+    FTI_Try(FTI_InitGroupsAndTypes(&FTI_Exec), "malloc arrays for groups and types.");
     FTI_Try(FTI_InitBasicTypes(FTI_Data), "create the basic data types.");
     if (FTI_Topo.myRank == 0) {
         FTI_Try(FTI_UpdateConf(&FTI_Conf, &FTI_Exec, FTI_Exec.reco), "update configuration file.");
@@ -199,15 +192,7 @@ int FTI_Status()
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_InitType(FTIT_type* type, int size)
-{
-    if (FTI_Exec.nbType == 0) {
-        //malloc memory for array for basic types
-        FTI_Exec.FTI_Type = malloc(11* sizeof(FTIT_type*));
-    } else if (FTI_Exec.nbType > 10) {
-        //append a space for new type
-        FTI_Exec.FTI_Type = realloc(FTI_Exec.FTI_Type, sizeof(FTIT_type*) * (FTI_Exec.nbType + 1));
-    }
-    
+{  
     type->id = FTI_Exec.nbType;
     type->size = size;
     type->structure = NULL;

--- a/src/api.c
+++ b/src/api.c
@@ -443,7 +443,6 @@ int FTI_InitGroup(FTIT_H5Group* h5group, char* name, FTIT_H5Group* parent)
     FTI_Exec.H5groups[FTI_Exec.nbGroup] = malloc(sizeof(FTIT_H5Group));
     *FTI_Exec.H5groups[FTI_Exec.nbGroup] = *h5group;
 
-    FTIT_H5Group* parentInArray = FTI_Exec.H5groups[parent->id];
     //assign a child and increment the childrenNo
     parentInArray->childrenID[parentInArray->childrenNo] = FTI_Exec.nbGroup;
     parentInArray->childrenNo++;

--- a/src/interface.h
+++ b/src/interface.h
@@ -217,6 +217,7 @@ void FTI_FreeTypesAndGroups(FTIT_execution* FTI_Exec);
     void FTI_OpenGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup, FTIT_H5Group** FTI_Group);
     void FTI_CloseGroup(FTIT_H5Group* ftiGroup, FTIT_H5Group** FTI_Group);
 #endif
+int FTI_InitGroupsAndTypes(FTIT_execution* FTI_Exec);
 int FTI_InitBasicTypes(FTIT_dataset* FTI_Data);
 int FTI_InitExecVars(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,

--- a/src/interface.h
+++ b/src/interface.h
@@ -210,8 +210,8 @@ int FTI_Try(int result, char* message);
 void FTI_MallocMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo);
 void FTI_FreeMeta(FTIT_execution* FTI_Exec);
 #ifdef ENABLE_HDF5
-    void FTI_CreateComplexType(FTIT_type* ftiType);
-    void FTI_CloseComplexType(FTIT_type* ftiType);
+    void FTI_CreateComplexType(FTIT_type* ftiType, FTIT_type** FTI_Type);
+    void FTI_CloseComplexType(FTIT_type* ftiType, FTIT_type** FTI_Type);
     void FTI_CreateGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup);
     void FTI_OpenGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup);
     void FTI_CloseGroup(FTIT_H5Group* ftiGroup);

--- a/src/interface.h
+++ b/src/interface.h
@@ -209,12 +209,13 @@ int FTI_VerifyChecksum(char* fileName, char* checksumToCmp);
 int FTI_Try(int result, char* message);
 void FTI_MallocMeta(FTIT_execution* FTI_Exec, FTIT_topology* FTI_Topo);
 void FTI_FreeMeta(FTIT_execution* FTI_Exec);
+void FTI_FreeTypesAndGroups(FTIT_execution* FTI_Exec);
 #ifdef ENABLE_HDF5
     void FTI_CreateComplexType(FTIT_type* ftiType, FTIT_type** FTI_Type);
     void FTI_CloseComplexType(FTIT_type* ftiType, FTIT_type** FTI_Type);
-    void FTI_CreateGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup);
-    void FTI_OpenGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup);
-    void FTI_CloseGroup(FTIT_H5Group* ftiGroup);
+    void FTI_CreateGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup, FTIT_H5Group** FTI_Group);
+    void FTI_OpenGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup, FTIT_H5Group** FTI_Group);
+    void FTI_CloseGroup(FTIT_H5Group* ftiGroup, FTIT_H5Group** FTI_Group);
 #endif
 int FTI_InitBasicTypes(FTIT_dataset* FTI_Data);
 int FTI_InitExecVars(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,

--- a/src/tools.c
+++ b/src/tools.c
@@ -368,6 +368,39 @@ void FTI_FreeMeta(FTIT_execution* FTI_Exec)
 
 /*-------------------------------------------------------------------------*/
 /**
+  @brief      It mallocs memory for the metadata.
+  @param      FTI_Exec        Execution metadata.
+  @param      FTI_Topo        Topology metadata.
+
+  This function mallocs the memory used for the metadata storage.
+
+ **/
+/*-------------------------------------------------------------------------*/
+int FTI_InitGroupsAndTypes(FTIT_execution* FTI_Exec) {
+    FTI_Exec->FTI_Type = malloc(sizeof(FTIT_type*) * FTI_BUFS);
+    if (FTI_Exec->FTI_Type == NULL) {
+        return FTI_NSCS;
+    }
+
+    FTI_Exec->H5groups = malloc(sizeof(FTIT_H5Group*) * FTI_BUFS);
+    if (FTI_Exec->H5groups == NULL) {
+        return FTI_NSCS;
+    }
+
+    FTI_Exec->H5groups[0] = malloc(sizeof(FTIT_H5Group));
+    if (FTI_Exec->H5groups[0] == NULL) {
+        return FTI_NSCS;
+    }
+
+    FTI_Exec->H5groups[0]->id = 0;
+    FTI_Exec->H5groups[0]->childrenNo = 0;
+    sprintf(FTI_Exec->H5groups[0]->name, "/");
+    FTI_Exec->nbGroup = 1;
+    return FTI_SCES;
+}
+
+/*-------------------------------------------------------------------------*/
+/**
   @brief      It frees memory for the types.
   @param      FTI_Exec        Execution metadata.
 


### PR DESCRIPTION
Types and groups are no longer needed to be saved on the side of the user. FTI now saves this structures and just recognize types and groups by ID. Fixed some hdf5 bugs