### PR TITLE
Issue209

### DIFF
--- a/include/fti.h
+++ b/include/fti.h
@@ -414,7 +414,7 @@ extern "C" {
         bool            stagingEnabled;
         bool            dcpEnabled;         /**< Enable differential ckpt.      */
         bool            keepL4Ckpt;         /**< TRUE if l4 ckpts to keep       */        
-	    bool            keepHeadsAlive;     /**< TRUE if heads return           */
+        bool            keepHeadsAlive;     /**< TRUE if heads return           */
         int             dcpMode;            /**< dCP mode.                      */
         int             dcpBlockSize;       /**< Block size for dCP hash        */
         char            cfgFile[FTI_BUFS];  /**< Configuration file name.       */

--- a/include/fti.h
+++ b/include/fti.h
@@ -41,6 +41,8 @@
 #define FTI_NSCS -1
 /** Token returned if recovery fails.                                      */
 #define FTI_NREC -2
+/** Token that indicates a head process in user space                      */
+#define FTI_HEAD 2
 
 /** Verbosity level to print only errors.                                  */
 #define FTI_EROR 4
@@ -412,7 +414,8 @@ extern "C" {
         bool            stagingEnabled;
         bool            dcpEnabled;         /**< Enable differential ckpt.      */
         bool            keepL4Ckpt;         /**< TRUE if l4 ckpts to keep       */        
-	int             dcpMode;            /**< dCP mode.                      */
+	    bool            keepHeadsAlive;     /**< TRUE if heads return           */
+        int             dcpMode;            /**< dCP mode.                      */
         int             dcpBlockSize;       /**< Block size for dCP hash        */
         char            cfgFile[FTI_BUFS];  /**< Configuration file name.       */
         int             saveLastCkpt;       /**< TRUE to save last checkpoint.  */

--- a/src/api.c
+++ b/src/api.c
@@ -146,6 +146,7 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
             }
         }
         FTI_Listen(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt); //infinite loop inside, can stop only by callling FTI_Finalize
+        return FTI_HEAD;
     }
     else { // If I am an application process
         // call in any case. treatment for diffCkpt disabled inside initializer.
@@ -1360,8 +1361,12 @@ int FTI_Finalize()
             FTI_FinalizeStage( &FTI_Exec, &FTI_Topo, &FTI_Conf );
         }
         MPI_Barrier(FTI_Exec.globalComm);
-        MPI_Finalize();
-        exit(0);
+        if ( !FTI_Conf.keepHeadsAlive ) { 
+            MPI_Finalize();
+            exit(0);
+        } else {
+            return FTI_SCES;
+        }
     }
 
     // Notice: The following code is only executed by the application procs

--- a/src/api.c
+++ b/src/api.c
@@ -146,6 +146,7 @@ int FTI_Init(char* configFile, MPI_Comm globalComm)
             }
         }
         FTI_Listen(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt); //infinite loop inside, can stop only by callling FTI_Finalize
+        // FTI_Listen only returns if FTI_Conf.keepHeadsAlive is TRUE
         return FTI_HEAD;
     }
     else { // If I am an application process

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -442,9 +442,17 @@ int FTI_Listen(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             FTI_Print("Head stopped listening.", FTI_DBUG);
             FTI_Finalize();
 
+            if ( FTI_Conf->keepHeadsAlive ) {
+                break;
+            }
+
         }
 
     }
+
+    // will be reached only if keepHeadsAlive is TRUE
+    return FTI_SCES;
+
 }
 
 /*-------------------------------------------------------------------------*/

--- a/src/conf.c
+++ b/src/conf.c
@@ -159,6 +159,7 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     FTI_Conf->stagingEnabled = (bool)iniparser_getboolean(ini, "Basic:enable_staging", 0);
 
     // Reading/setting configuration metadata
+    FTI_Conf->keepHeadsAlive = (bool)iniparser_getboolean(ini, "Basic:keep_heads_alive", 0);
     FTI_Conf->dcpEnabled = (bool)iniparser_getboolean(ini, "Basic:enable_dcp", 0);
     FTI_Conf->dcpMode = (int)iniparser_getint(ini, "Basic:dcp_mode", -1) + FTI_DCP_MODE_OFFSET;
     FTI_Conf->dcpBlockSize = (int)iniparser_getint(ini, "Basic:dcp_block_size", -1);
@@ -285,6 +286,11 @@ int FTI_TestConfig(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
     }
     if (FTI_Conf->blockSize > (2048 * 1024) || FTI_Conf->blockSize < (1 * 1024)) {
         FTI_Print("Block size needs to be set between 1 and 2048.", FTI_WARN);
+        return FTI_NSCS;
+    }
+
+    if ( FTI_Conf->keepHeadsAlive && ( FTI_Topo->nbHeads == 0 ) ) {
+        FTI_Print("Head feature is disabled but 'keep_heads_alive' is activated. Incompatiple setting!.", FTI_WARN);
         return FTI_NSCS;
     }
 

--- a/src/interface.h
+++ b/src/interface.h
@@ -124,8 +124,7 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_Listen(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
-        FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt)
-        __attribute__((noreturn));
+        FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_HandleCkptRequest(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt);
 int FTI_HandleStageRequest(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,


### PR DESCRIPTION
Adds a setting -> [BASIC] keep_heads_alive = [0 (default) |1]

If set to 1, the heads return from FTI_Init with return value 'FTI_HEAD'.

If head = 0 and keep_heads_alive = 1, the configuration check fails and FTI issues a warning.