### PR TITLE
Parenthesizing parameters of a macro

### DIFF
--- a/include/fti-int/incremental_checkpoint.h
+++ b/include/fti-int/incremental_checkpoint.h
@@ -12,7 +12,7 @@
 #define FTI_ICP_ACTV 1
 #define FTI_ICP_FAIL 2
 
-#define FTI_GT(NUM1, NUM2) (NUM1 > NUM2) ? NUM1 : NUM2
+#define FTI_GT(NUM1, NUM2) ((NUM1) > (NUM2)) ? NUM1 : NUM2
 #define FTI_PO_FH FILE*
 #define FTI_FF_FH int
 #define FTI_MI_FH MPI_File


### PR DESCRIPTION
I found an issue in the definition of the GT macro:  depending on the arguments it may produce unexpected values. Below you can find a simple example that shows this problem:
```cpp
#include<stdio.h>
#define A 2
#define B 4
#define C 8

#define GT(M, N) (M > N) ? M : N
int main()
{
    printf("The greatest number among: %d, %d, and %d is %d\n", A, B, C, GT(A, GT(B, C)));
}
```
`./bin`
`The greatest number among: 2, 4, and 8 is 2`

Parenthesizing the parameters of the macro make it work.