### PR TITLE
Failure injection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ set(SRC_FTI
 	src/api.c src/checkpoint.c src/conf.c src/meta.c
 	src/postckpt.c src/postreco.c src/recover.c
 	src/tools.c src/topo.c src/ftiff.c src/hdf5.c
-	src/diff-checkpoint.c src/stage.c src/incremental-checkpoint.c)
+	src/diff-checkpoint.c src/stage.c src/incremental-checkpoint.c src/failure-injection.c)
 
 # add compiler flags
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ option(ENABLE_EXAMPLES "Enables the generation of examples" ON)
 option(ENABLE_SIONLIB "Enables the parallel I/O SIONlib for FTI" OFF)
 option(ENABLE_HDF5 "Enables the HDF5 checkpoints for FTI" OFF)
 option(ENABLE_TESTS "Enables the generation of tests" ON)
+option(ENABLE_FI_IO "Enables the I/O failure injection mechanism" OFF)
 option(ENABLE_LUSTRE "Enables Lustre Support" OFF)
 option(ENABLE_DOCU "Enables the generation of a Doxygen documentation" OFF)
 
@@ -228,6 +229,10 @@ if(ENABLE_HDF5)
 		*  -DHDF5_ROOT as the path to the HDF5 installation to use.
 		**")
 	endif()
+endif()
+
+if(ENABLE_FI_IO)
+    add_definitions(-DENABLE_FTI_FI_IO)
 endif()
 
 set(FTI_TARGETS fti.static fti.shared)

--- a/examples/heatdis.c
+++ b/examples/heatdis.c
@@ -9,29 +9,132 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <stdbool.h>
 #include <fti.h>
+#include <time.h>
 
 
-#define PRECISION   0.005
-#define ITER_TIMES  5000
-#define ITER_OUT    500
+#define PRECISION   0.0000001
+#define ITER_TIMES  1000000
+#define ITER_OUT    5
 #define WORKTAG     50
 #define REDUCE      5
 
+int FIRST_CHECKPOINT;
+int SECOND_CHECKPOINT;
+int CHECKPOINT_ITER;
+int LAST_CHECKPOINT;
+bool isRestart;
+bool toRecover;
+bool toFinalize;
+bool isCheckpointed;
+
+void Snapshot_distance( int iter, double wtime, int rank ) {
+    
+    static double ckpt1_t;
+
+    if ( isRestart ) {
+        if ( toRecover ) {
+            FTI_Recover();
+            toRecover = false;
+        }
+        if ( toFinalize ) {
+            FTI_Finalize();
+            MPI_Finalize();
+            exit(EXIT_SUCCESS);
+        }
+        if ( (iter%5) == 0 ) {
+            toFinalize = true;
+        }
+    } else {
+        if ( iter == FIRST_CHECKPOINT ) {
+            FTI_Checkpoint( iter, 2 );
+            ckpt1_t = MPI_Wtime();
+        }
+        if ( iter == SECOND_CHECKPOINT ) {
+            if (rank == 0) {
+                printf("Second checkpoint after %lf seconds.\n", MPI_Wtime() - ckpt1_t);
+            }
+            FTI_Checkpoint( iter, 2 );
+            isCheckpointed = true;
+        }
+        if ( toFinalize ) {
+            if (rank == 0) {
+                printf("Execution finished in %lf seconds.\n", MPI_Wtime() - wtime);
+            }
+            MPI_Finalize();
+            exit(EXIT_SUCCESS);
+        }
+        if ( (iter%5) == 0 && isCheckpointed ) {
+            toFinalize = true;
+        }
+    }
+}
+
+void Snapshot( int iter, double wtime, int rank, double *ptr1, double *ptr2 ) {
+    
+    static double ckpt1_t;
+
+    if ( isRestart ) {
+        if ( toRecover ) {
+            FTI_Recover();
+            toRecover = false;
+        }
+        if ( toFinalize ) {
+            FTI_Finalize();
+            MPI_Finalize();
+            exit(EXIT_SUCCESS);
+        }
+        if ( (iter%5) == 0 ) {
+            toFinalize = true;
+        }
+    } else {
+        if ( (iter%CHECKPOINT_ITER == 0) && iter > 0 ) {
+            FTI_Checkpoint( iter, 2 );
+            ckpt1_t = MPI_Wtime();
+        }
+        if ( iter == LAST_CHECKPOINT ) {
+            if (rank == 0) {
+                printf("Execution finished in %lf seconds.\n", MPI_Wtime() - wtime);
+            }
+            free(ptr1);
+            free(ptr2);
+            FTI_Finalize();
+            MPI_Finalize();
+            exit(EXIT_SUCCESS);
+        }
+    }
+}
 
 void initData(int nbLines, int M, int rank, double *h)
 {
     int i, j;
+    srand(time(NULL));
     for (i = 0; i < nbLines; i++) {
         for (j = 0; j < M; j++) {
-            h[(i*M)+j] = 0;
+            if((i%2 == 0) && (rank%512 == 0)) {
+                if(j%2 == 0) {
+                    h[(i*M)+j] = rand()%100+1;
+                } else {
+                    h[(i*M)+j] = 0;
+                }
+            }
+            else if((i%2 != 0) && (rank%512 == 0)) {
+                if(j%2 != 0) {
+                    h[(i*M)+j] = rand()%100+1;
+                } else {
+                    h[(i*M)+j] = 0;
+                }
+            } else {
+                h[(i*M)+j] = 0;
+            }
         }
     }
-    if (rank == 0) {
-        for (j = (M*0.1); j < (M*0.9); j++) {
-            h[j] = 100;
-        }
-    }
+//    if (rank%2 == 0) {
+//        for (j = (M*0.1); j < (M*0.9); j++) {
+//            h[j] = rand()%100+1;
+//        }
+//    }
 }
 
 
@@ -85,10 +188,22 @@ int main(int argc, char *argv[])
 
     MPI_Init(&argc, &argv);
     FTI_Init(argv[2], MPI_COMM_WORLD);
-
+    
     MPI_Comm_size(FTI_COMM_WORLD, &nbProcs);
     MPI_Comm_rank(FTI_COMM_WORLD, &rank);
+    
+    toFinalize = false;
+    isCheckpointed = false;
+    if ( FTI_Status() == 1 ) {
+        toRecover = true;
+        isRestart = true;
+    }
 
+    //FIRST_CHECKPOINT = atoi(getenv("FTI_FIRST_CKPT"));
+    //SECOND_CHECKPOINT = atoi(getenv("FTI_SECOND_CKPT"));
+    CHECKPOINT_ITER = atoi(getenv("FTI_CKPT_ITER"));
+    LAST_CHECKPOINT = atoi(getenv("FTI_LAST_CKPT"));
+    
     arg = atoi(argv[1]);
     M = (int)sqrt((double)(arg * 1024.0 * 512.0 * nbProcs)/sizeof(double));
     nbLines = (M / nbProcs)+3;
@@ -109,13 +224,13 @@ int main(int argc, char *argv[])
 
     wtime = MPI_Wtime();
     for (i = 0; i < ITER_TIMES; i++) {
-        int checkpointed = FTI_Snapshot();
+        Snapshot( i, wtime, rank, h, g );
         localerror = doWork(nbProcs, rank, M, nbLines, g, h);
-        if (((i%ITER_OUT) == 0) && (rank == 0)) {
-            printf("Step : %d, error = %f\n", i, globalerror);
-        }
         if ((i%REDUCE) == 0) {
             MPI_Allreduce(&localerror, &globalerror, 1, MPI_DOUBLE, MPI_MAX, FTI_COMM_WORLD);
+        }
+        if (((i%ITER_OUT) == 0) && (rank == 0)) {
+            printf("Step : %d, error = %f\n", i, globalerror);
         }
         if(globalerror < PRECISION) {
             break;

--- a/examples/heatdis.c
+++ b/examples/heatdis.c
@@ -48,14 +48,14 @@ void Snapshot_distance( int iter, double wtime, int rank ) {
         }
     } else {
         if ( iter == FIRST_CHECKPOINT ) {
-            FTI_Checkpoint( iter, 2 );
+            FTI_Checkpoint( iter, 3 );
             ckpt1_t = MPI_Wtime();
         }
         if ( iter == SECOND_CHECKPOINT ) {
             if (rank == 0) {
                 printf("Second checkpoint after %lf seconds.\n", MPI_Wtime() - ckpt1_t);
             }
-            FTI_Checkpoint( iter, 2 );
+            FTI_Checkpoint( iter, 3 );
             isCheckpointed = true;
         }
         if ( toFinalize ) {

--- a/examples/heatdis.c
+++ b/examples/heatdis.c
@@ -9,132 +9,29 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <stdbool.h>
 #include <fti.h>
-#include <time.h>
 
 
-#define PRECISION   0.0000001
-#define ITER_TIMES  1000000
-#define ITER_OUT    5
+#define PRECISION   0.005
+#define ITER_TIMES  5000
+#define ITER_OUT    500
 #define WORKTAG     50
 #define REDUCE      5
 
-int FIRST_CHECKPOINT;
-int SECOND_CHECKPOINT;
-int CHECKPOINT_ITER;
-int LAST_CHECKPOINT;
-bool isRestart;
-bool toRecover;
-bool toFinalize;
-bool isCheckpointed;
-
-void Snapshot_distance( int iter, double wtime, int rank ) {
-    
-    static double ckpt1_t;
-
-    if ( isRestart ) {
-        if ( toRecover ) {
-            FTI_Recover();
-            toRecover = false;
-        }
-        if ( toFinalize ) {
-            FTI_Finalize();
-            MPI_Finalize();
-            exit(EXIT_SUCCESS);
-        }
-        if ( (iter%5) == 0 ) {
-            toFinalize = true;
-        }
-    } else {
-        if ( iter == FIRST_CHECKPOINT ) {
-            FTI_Checkpoint( iter, 3 );
-            ckpt1_t = MPI_Wtime();
-        }
-        if ( iter == SECOND_CHECKPOINT ) {
-            if (rank == 0) {
-                printf("Second checkpoint after %lf seconds.\n", MPI_Wtime() - ckpt1_t);
-            }
-            FTI_Checkpoint( iter, 3 );
-            isCheckpointed = true;
-        }
-        if ( toFinalize ) {
-            if (rank == 0) {
-                printf("Execution finished in %lf seconds.\n", MPI_Wtime() - wtime);
-            }
-            MPI_Finalize();
-            exit(EXIT_SUCCESS);
-        }
-        if ( (iter%5) == 0 && isCheckpointed ) {
-            toFinalize = true;
-        }
-    }
-}
-
-void Snapshot( int iter, double wtime, int rank, double *ptr1, double *ptr2 ) {
-    
-    static double ckpt1_t;
-
-    if ( isRestart ) {
-        if ( toRecover ) {
-            FTI_Recover();
-            toRecover = false;
-        }
-        if ( toFinalize ) {
-            FTI_Finalize();
-            MPI_Finalize();
-            exit(EXIT_SUCCESS);
-        }
-        if ( (iter%5) == 0 ) {
-            toFinalize = true;
-        }
-    } else {
-        if ( (iter%CHECKPOINT_ITER == 0) && iter > 0 ) {
-            FTI_Checkpoint( iter, 2 );
-            ckpt1_t = MPI_Wtime();
-        }
-        if ( iter == LAST_CHECKPOINT ) {
-            if (rank == 0) {
-                printf("Execution finished in %lf seconds.\n", MPI_Wtime() - wtime);
-            }
-            free(ptr1);
-            free(ptr2);
-            FTI_Finalize();
-            MPI_Finalize();
-            exit(EXIT_SUCCESS);
-        }
-    }
-}
 
 void initData(int nbLines, int M, int rank, double *h)
 {
     int i, j;
-    srand(time(NULL));
     for (i = 0; i < nbLines; i++) {
         for (j = 0; j < M; j++) {
-            if((i%2 == 0) && (rank%512 == 0)) {
-                if(j%2 == 0) {
-                    h[(i*M)+j] = rand()%100+1;
-                } else {
-                    h[(i*M)+j] = 0;
-                }
-            }
-            else if((i%2 != 0) && (rank%512 == 0)) {
-                if(j%2 != 0) {
-                    h[(i*M)+j] = rand()%100+1;
-                } else {
-                    h[(i*M)+j] = 0;
-                }
-            } else {
-                h[(i*M)+j] = 0;
-            }
+            h[(i*M)+j] = 0;
         }
     }
-//    if (rank%2 == 0) {
-//        for (j = (M*0.1); j < (M*0.9); j++) {
-//            h[j] = rand()%100+1;
-//        }
-//    }
+    if (rank == 0) {
+        for (j = (M*0.1); j < (M*0.9); j++) {
+            h[j] = 100;
+        }
+    }
 }
 
 
@@ -188,22 +85,10 @@ int main(int argc, char *argv[])
 
     MPI_Init(&argc, &argv);
     FTI_Init(argv[2], MPI_COMM_WORLD);
-    
+
     MPI_Comm_size(FTI_COMM_WORLD, &nbProcs);
     MPI_Comm_rank(FTI_COMM_WORLD, &rank);
-    
-    toFinalize = false;
-    isCheckpointed = false;
-    if ( FTI_Status() == 1 ) {
-        toRecover = true;
-        isRestart = true;
-    }
 
-    //FIRST_CHECKPOINT = atoi(getenv("FTI_FIRST_CKPT"));
-    //SECOND_CHECKPOINT = atoi(getenv("FTI_SECOND_CKPT"));
-    CHECKPOINT_ITER = atoi(getenv("FTI_CKPT_ITER"));
-    LAST_CHECKPOINT = atoi(getenv("FTI_LAST_CKPT"));
-    
     arg = atoi(argv[1]);
     M = (int)sqrt((double)(arg * 1024.0 * 512.0 * nbProcs)/sizeof(double));
     nbLines = (M / nbProcs)+3;
@@ -224,13 +109,13 @@ int main(int argc, char *argv[])
 
     wtime = MPI_Wtime();
     for (i = 0; i < ITER_TIMES; i++) {
-        Snapshot( i, wtime, rank, h, g );
+        int checkpointed = FTI_Snapshot();
         localerror = doWork(nbProcs, rank, M, nbLines, g, h);
-        if ((i%REDUCE) == 0) {
-            MPI_Allreduce(&localerror, &globalerror, 1, MPI_DOUBLE, MPI_MAX, FTI_COMM_WORLD);
-        }
         if (((i%ITER_OUT) == 0) && (rank == 0)) {
             printf("Step : %d, error = %f\n", i, globalerror);
+        }
+        if ((i%REDUCE) == 0) {
+            MPI_Allreduce(&localerror, &globalerror, 1, MPI_DOUBLE, MPI_MAX, FTI_COMM_WORLD);
         }
         if(globalerror < PRECISION) {
             break;

--- a/src/api.c
+++ b/src/api.c
@@ -100,7 +100,9 @@ FTIT_type FTI_LDBE;
 /*-------------------------------------------------------------------------*/
 int FTI_Init(char* configFile, MPI_Comm globalComm)
 {
-    init_fi();
+#ifdef ENABLE_FTI_FI_IO
+    FTI_InitFIIO();
+#endif
     FTI_InitExecVars(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt, &FTI_Inje);
     FTI_Exec.globalComm = globalComm;
     MPI_Comm_rank(FTI_Exec.globalComm, &FTI_Topo.myRank);

--- a/src/api.c
+++ b/src/api.c
@@ -100,6 +100,7 @@ FTIT_type FTI_LDBE;
 /*-------------------------------------------------------------------------*/
 int FTI_Init(char* configFile, MPI_Comm globalComm)
 {
+    init_fi();
     FTI_InitExecVars(&FTI_Conf, &FTI_Exec, &FTI_Topo, FTI_Ckpt, &FTI_Inje);
     FTI_Exec.globalComm = globalComm;
     MPI_Comm_rank(FTI_Exec.globalComm, &FTI_Topo.myRank);

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -272,7 +272,7 @@ int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     double t1 = MPI_Wtime(); //Start time
 
-    int res; // = FTI_NSCS; //Response from post-processing functions
+    int res; //Response from post-processing functions
     switch (FTI_Exec->ckptLvel) {
         case 4:
             res = FTI_Flush(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, 0);

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -599,7 +599,6 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int fwrite_errno;
         while (written < FTI_Data[i].count && !ferror(fd)) {
             errno = 0;
-            //written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
             int returnVal;
             FTI_FI_FWRITE( returnVal, ((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd, fn );
             written += returnVal; 

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -599,10 +599,10 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int fwrite_errno;
         while (written < FTI_Data[i].count && !ferror(fd)) {
             errno = 0;
-            //written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
-            int err;
-            FI_FWRITE( err, ((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd, fn );
-            written += err; 
+            written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
+            //int err;
+            //FI_FWRITE( err, ((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd, fn );
+            //written += err; 
             fwrite_errno = errno;
         }
         if (ferror(fd)) {

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -272,7 +272,7 @@ int FTI_PostCkpt(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     double t1 = MPI_Wtime(); //Start time
 
-    int res; //Response from post-processing functions
+    int res; // = FTI_NSCS; //Response from post-processing functions
     switch (FTI_Exec->ckptLvel) {
         case 4:
             res = FTI_Flush(FTI_Conf, FTI_Exec, FTI_Topo, FTI_Ckpt, 0);
@@ -599,7 +599,10 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int fwrite_errno;
         while (written < FTI_Data[i].count && !ferror(fd)) {
             errno = 0;
-            written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
+            //written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
+            int err;
+            FI_FWRITE( err, ((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd, fn );
+            written += err; 
             fwrite_errno = errno;
         }
         if (ferror(fd)) {

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -599,10 +599,10 @@ int FTI_WritePosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         int fwrite_errno;
         while (written < FTI_Data[i].count && !ferror(fd)) {
             errno = 0;
-            written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
-            //int err;
-            //FI_FWRITE( err, ((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd, fn );
-            //written += err; 
+            //written += fwrite(((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd);
+            int returnVal;
+            FTI_FI_FWRITE( returnVal, ((char*)FTI_Data[i].ptr) + (FTI_Data[i].eleSize*written), FTI_Data[i].eleSize, FTI_Data[i].count - written, fd, fn );
+            written += returnVal; 
             fwrite_errno = errno;
         }
         if (ferror(fd)) {

--- a/src/failure-injection.c
+++ b/src/failure-injection.c
@@ -17,7 +17,7 @@ unsigned int FUNCTION( const char *testFunction ) {
     return !res;
 }
 
-void init_fi() {
+void FTI_InitFIIO() {
 
     char *env;
     if ( (env = getenv("FTI_FI_PROBABILITY")) != NULL ) {

--- a/src/failure-injection.c
+++ b/src/failure-injection.c
@@ -1,19 +1,35 @@
 #include "failure-injection.h"
 #include <stdlib.h>
+#include <fti.h>
+#include <string.h>
+#include <stdio.h>
 
-static float __PROBABILITY__ ;
+static float _PROBABILITY ;
+static char _FUNCTION[FTI_BUFS];
 
 float PROBABILITY() {
-    return __PROBABILITY__;
+    return _PROBABILITY;
+}
+
+unsigned int FUNCTION( const char *testFunction ) {
+    int len = ( strlen(testFunction) > FTI_BUFS ) ? FTI_BUFS : strlen(testFunction);
+    int res = strncmp( testFunction, _FUNCTION, len );
+    return !res;
 }
 
 void init_fi() {
 
     char *env;
     if ( (env = getenv("FTI_FI_PROBABILITY")) != NULL ) {
-        __PROBABILITY__ = atof(env);
+        _PROBABILITY = atof(env);
     } else {
-        __PROBABILITY__ = 0.01;
+        _PROBABILITY = 0.01;
+    }
+    if ( (env = getenv("FTI_FI_FUNCTION")) != NULL ) {
+        strncpy( _FUNCTION, env, FTI_BUFS-1 );
+        _FUNCTION[FTI_BUFS-1] = '\0';
+    } else {
+        _FUNCTION[0] = '\0';
     }
 
 }

--- a/src/failure-injection.c
+++ b/src/failure-injection.c
@@ -1,0 +1,19 @@
+#include "failure-injection.h"
+#include <stdlib.h>
+
+static float __PROBABILITY__ ;
+
+float PROBABILITY() {
+    return __PROBABILITY__;
+}
+
+void init_fi() {
+
+    char *env;
+    if ( (env = getenv("FTI_FI_PROBABILITY")) != NULL ) {
+        __PROBABILITY__ = atof(env);
+    } else {
+        __PROBABILITY__ = 0.01;
+    }
+
+}

--- a/src/failure-injection.h
+++ b/src/failure-injection.h
@@ -1,3 +1,67 @@
+/**
+ *  Copyright (c) 2017 Leonardo A. Bautista-Gomez
+ *  All rights reserved
+ *
+ *  FTI - A multi-level checkpointing library for C/C++/Fortran applications
+ *
+ *  Revision 1.0 : Fault Tolerance Interface (FTI)
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its contributors
+ *  may be used to endorse or promote products derived from this software without
+ *  specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  @brief  Defines wrapper for POSIX write functions to enable failure injection.
+ *
+ *  In order ro enable the Failure Injection for I/O (FIIO) mechanism,
+ *  we need to pass -DENABLE_FI_IO to the cmake command. We can inject
+ *  failures for the write (or fwrite) functions in the following
+ *  functions:
+ *  
+ *  - FTI_WritePosix
+ *  - FTIFF_WriteFTIFF
+ *  - FTI_RecvPtner
+ *  - FTI_RSenc
+ *  - FTI_FlushPosix
+ *
+ *  In order to select the function where we want to inject the failure,
+ *  we need to set the environment variable FTI_FI_FUNCTION. For
+ *  instance:
+ *
+ *  FTI_FI_FUNCTION=FTI_WritePosix mpirun -n 8 ./application
+ *
+ *  We can set the probability for the failure to hapen by setting the
+ *  environment variable FTI_FI_PROBABILITY. For instance to inject a
+ *  failure in function FTI_WritePosix with probability of 0.5:
+ *
+ *  FTI_FI_FUNCTION=FTI_WritePosix FTI_FI_PROBABILITY=0.5 mpirun -n 8 ./application
+ *
+ *  The default value for the probability is 0.1.
+ *
+ *  @author Kai Keller (kellekai@gmx.de)
+ *  @file   failure-injection.h
+ *  @date   December, 2018 
+ */
 #ifndef _FAILURE_INJECTION_H
 #define _FAILURE_INJECTION_H
 

--- a/src/failure-injection.h
+++ b/src/failure-injection.h
@@ -17,24 +17,21 @@ static inline uint64_t get_ruint() {
     return buffer%INT_MAX;
 }
 
-void init_fi();
+void FTI_InitFIIO();
 float PROBABILITY();
 unsigned int FUNCTION( const char *testFunction );
 
-#ifdef ENABLE_FI
+#ifdef ENABLE_FTI_FI_IO
 #define FTI_FI_WRITE( ERR, FD, BUF, COUNT, FN ) \
     do { \
         if( FUNCTION(__FUNCTION__) ) { \
             if( get_ruint() < ((uint64_t)((double)PROBABILITY()*INT_MAX)) ) { \
                 close(FD); \
                 FD = open(FN, O_RDONLY); \
-                ERR = write( FD, BUF, COUNT ); \
-            } else  { \
-                ERR = write( FD, BUF, COUNT ); \
-            } \
-        } else  { \
-            ERR = write( FD, BUF, COUNT ); \
+            }  \
         } \
+        ERR = write( FD, BUF, COUNT ); \
+        (void)(ERR); \
     } while(0)
 #define FTI_FI_FWRITE( ERR, BUF, SIZE, COUNT, FSTREAM, FN ) \
     do { \
@@ -42,13 +39,10 @@ unsigned int FUNCTION( const char *testFunction );
             if( get_ruint() < ((uint64_t)((double)PROBABILITY()*INT_MAX)) ) { \
                 fclose(FSTREAM); \
                 FSTREAM = fopen(FN, "rb"); \
-                ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
-            } else  { \
-                ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
             } \
-        } else  { \
-            ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
         } \
+        ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
+        (void)(ERR); \
     } while(0)
 #else
 #define FTI_FI_WRITE( ERR, FD, BUF, COUNT, FN ) ( ERR = write( FD, BUF, COUNT ) )

--- a/src/failure-injection.h
+++ b/src/failure-injection.h
@@ -1,6 +1,7 @@
 #ifndef _FAILURE_INJECTION_H
 #define _FAILURE_INJECTION_H
 
+#include <fti.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -17,33 +18,41 @@ static inline uint64_t get_ruint() {
 }
 
 void init_fi();
-
 float PROBABILITY();
+unsigned int FUNCTION( const char *testFunction );
 
 #ifdef ENABLE_FI
-#define FI_WRITE( ERR, FD, BUF, COUNT, FN ) \
+#define FTI_FI_WRITE( ERR, FD, BUF, COUNT, FN ) \
     do { \
-        if( get_ruint() < ((uint64_t)((double)PROBABILITY()*INT_MAX)) ) { \
-            close(FD); \
-            FD = open(FN, O_RDONLY); \
-            ERR = write( FD, BUF, COUNT ); \
+        if( FUNCTION(__FUNCTION__) ) { \
+            if( get_ruint() < ((uint64_t)((double)PROBABILITY()*INT_MAX)) ) { \
+                close(FD); \
+                FD = open(FN, O_RDONLY); \
+                ERR = write( FD, BUF, COUNT ); \
+            } else  { \
+                ERR = write( FD, BUF, COUNT ); \
+            } \
         } else  { \
             ERR = write( FD, BUF, COUNT ); \
         } \
     } while(0)
-#define FI_FWRITE( ERR, BUF, SIZE, COUNT, FSTREAM, FN ) \
+#define FTI_FI_FWRITE( ERR, BUF, SIZE, COUNT, FSTREAM, FN ) \
     do { \
-        if( get_ruint() < ((uint64_t)((double)PROBABILITY()*INT_MAX)) ) { \
-            fclose(FSTREAM); \
-            FSTREAM = fopen(FN, "rb"); \
-            ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
+        if( FUNCTION(__FUNCTION__) ) { \
+            if( get_ruint() < ((uint64_t)((double)PROBABILITY()*INT_MAX)) ) { \
+                fclose(FSTREAM); \
+                FSTREAM = fopen(FN, "rb"); \
+                ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
+            } else  { \
+                ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
+            } \
         } else  { \
             ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ); \
         } \
     } while(0)
 #else
-#define FI_WRITE( ERR, FD, BUF, COUNT, FN ) ERR = write( FD, BUF, COUNT )
-#define FI_FWRITE( ERR, BUF, SIZE, COUNT, FSTREAM, FN ) ERR = fwrite( BUF, SIZE, COUNT, FSTREAM )
+#define FTI_FI_WRITE( ERR, FD, BUF, COUNT, FN ) ( ERR = write( FD, BUF, COUNT ) )
+#define FTI_FI_FWRITE( ERR, BUF, SIZE, COUNT, FSTREAM, FN ) ( ERR = fwrite( BUF, SIZE, COUNT, FSTREAM ) )
 #endif
 
 #endif //_FAILURE_INJECTION_H

--- a/src/ftiff.c
+++ b/src/ftiff.c
@@ -1176,14 +1176,16 @@ int FTIFF_WriteFTIFF(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     
                     int try = 0; 
                     do {
-                        FTI_FI_WRITE( WRITTEN, fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow, fn );
-                        if ( WRITTEN == -1 ) {
+                        int returnVal;
+                        FTI_FI_WRITE( returnVal, fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow, fn );
+                        if ( returnVal == -1 ) {
                             snprintf(str, FTI_BUFS, "FTI-FF: WriteFTIFF - Dataset #%d could not be written to file: %s", currentdbvar->id, fn);
                             FTI_Print(str, FTI_EROR);
                             close(fd);
                             errno = 0;
                             return FTI_NSCS;
                         }
+                        WRITTEN += returnVal;
                         try++;
                     } while ((WRITTEN < cpynow) && (try < 10));
                     

--- a/src/ftiff.c
+++ b/src/ftiff.c
@@ -1176,8 +1176,9 @@ int FTIFF_WriteFTIFF(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     
                     int try = 0; 
                     do {
-                        WRITTEN += write( fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow );
-                        if ( fd == -1 ) {
+                        //WRITTEN += write( fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow );
+                        FI_WRITE( WRITTEN, fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow, fn );
+                        if ( WRITTEN == -1 ) {
                             snprintf(str, FTI_BUFS, "FTI-FF: WriteFTIFF - Dataset #%d could not be written to file: %s", currentdbvar->id, fn);
                             FTI_Print(str, FTI_EROR);
                             close(fd);

--- a/src/ftiff.c
+++ b/src/ftiff.c
@@ -1176,7 +1176,6 @@ int FTIFF_WriteFTIFF(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     
                     int try = 0; 
                     do {
-                        //WRITTEN += write( fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow );
                         FTI_FI_WRITE( WRITTEN, fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow, fn );
                         if ( WRITTEN == -1 ) {
                             snprintf(str, FTI_BUFS, "FTI-FF: WriteFTIFF - Dataset #%d could not be written to file: %s", currentdbvar->id, fn);

--- a/src/ftiff.c
+++ b/src/ftiff.c
@@ -1177,7 +1177,7 @@ int FTIFF_WriteFTIFF(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
                     int try = 0; 
                     do {
                         //WRITTEN += write( fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow );
-                        FI_WRITE( WRITTEN, fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow, fn );
+                        FTI_FI_WRITE( WRITTEN, fd, (FTI_ADDRPTR) (chunk_addr+cpycnt), cpynow, fn );
                         if ( WRITTEN == -1 ) {
                             snprintf(str, FTI_BUFS, "FTI-FF: WriteFTIFF - Dataset #%d could not be written to file: %s", currentdbvar->id, fn);
                             FTI_Print(str, FTI_EROR);

--- a/src/interface.h
+++ b/src/interface.h
@@ -39,7 +39,6 @@
 #ifndef _FTI_INTERFACE_H
 #define _FTI_INTERFACE_H
 
-#define ENABLE_FI
 
 #include "failure-injection.h"
 

--- a/src/interface.h
+++ b/src/interface.h
@@ -39,6 +39,10 @@
 #ifndef _FTI_INTERFACE_H
 #define _FTI_INTERFACE_H
 
+#define ENABLE_FI
+
+#include "failure-injection.h"
+
 #include "fti.h"
 #include "ftiff.h"
 

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -159,8 +159,7 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
         MPI_Recv(buffer, recvSize, MPI_CHAR, source, FTI_Conf->generalTag, FTI_Exec->groupComm, MPI_STATUS_IGNORE);
         int err;
         FTI_FI_FWRITE( err, buffer, sizeof(char), recvSize, pfd, pfn );
-        //fwrite(buffer, sizeof(char), recvSize, pfd);
-
+        
         if (ferror(pfd)) {
             FTI_Print("Error writing data to L2 ptner file", FTI_EROR);
 
@@ -408,7 +407,6 @@ int FTI_RSenc(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             }
 
             // Writting encoded checkpoints
-            //fwrite(coding, sizeof(char), remBsize, efd);
             int returnVal;
             FTI_FI_FWRITE( returnVal, coding, sizeof(char), remBsize, efd, efn );
             if ( ferror( efd ) ) {
@@ -777,7 +775,6 @@ int FTI_FlushPosix(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
             int returnVal;
             FTI_FI_FWRITE( returnVal, readData, sizeof(char), bytes, gfd, gfn );
-            //fwrite(readData, sizeof(char), bytes, gfd);
             if (ferror(gfd)) {
                 FTI_Print("L4 cannot write to the ckpt. file in the PFS.", FTI_EROR);
                 free(readData);

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -157,7 +157,9 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
     while (toRecv > 0) {
         int recvSize = (toRecv > FTI_Conf->blockSize) ? FTI_Conf->blockSize : toRecv;
         MPI_Recv(buffer, recvSize, MPI_CHAR, source, FTI_Conf->generalTag, FTI_Exec->groupComm, MPI_STATUS_IGNORE);
-        fwrite(buffer, sizeof(char), recvSize, pfd);
+        int err;
+        FI_FWRITE( err, buffer, sizeof(char), recvSize, pfd, pfn );
+        //fwrite(buffer, sizeof(char), recvSize, pfd);
 
         if (ferror(pfd)) {
             FTI_Print("Error writing data to L2 ptner file", FTI_DBUG);

--- a/src/postckpt.c
+++ b/src/postckpt.c
@@ -157,8 +157,8 @@ int FTI_RecvPtner(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec, FTIT_c
     while (toRecv > 0) {
         int recvSize = (toRecv > FTI_Conf->blockSize) ? FTI_Conf->blockSize : toRecv;
         MPI_Recv(buffer, recvSize, MPI_CHAR, source, FTI_Conf->generalTag, FTI_Exec->groupComm, MPI_STATUS_IGNORE);
-        int err;
-        FTI_FI_FWRITE( err, buffer, sizeof(char), recvSize, pfd, pfn );
+        int returnVal;
+        FTI_FI_FWRITE( returnVal, buffer, sizeof(char), recvSize, pfd, pfn );
         
         if (ferror(pfd)) {
             FTI_Print("Error writing data to L2 ptner file", FTI_EROR);


### PR DESCRIPTION
 In order ro enable the Failure Injection for I/O (FIIO) mechanism,
 we need to pass -DENABLE_FI_IO to the cmake command. We can inject
 failures for the write (or fwrite) functions in the following
 functions:
 
 - FTI_WritePosix
 - FTIFF_WriteFTIFF
 - FTI_RecvPtner
 - FTI_RSenc
 - FTI_FlushPosix
 
 In order to select the function where we want to inject the failure,
 we need to set the environment variable FTI_FI_FUNCTION. For
 instance:
 
 FTI_FI_FUNCTION=FTI_WritePosix mpirun -n 8 ./application
 
 We can set the probability for the failure to hapen by setting the
 environment variable FTI_FI_PROBABILITY. For instance to inject a
 failure in function FTI_WritePosix with probability of 0.5:
 
 FTI_FI_FUNCTION=FTI_WritePosix FTI_FI_PROBABILITY=0.5 mpirun -n 8 ./application
 
 The default value for the probability is 0.1.
