### PR TITLE
Refactoring and small code improvements for CI and ITF scripts

### DIFF
--- a/testing/tools/ci/build.sh
+++ b/testing/tools/ci/build.sh
@@ -27,11 +27,11 @@ intel | Intel)
     export MPICCPATH='/opt/intel/compilers_and_libraries_2018.3.222/linux/mpi/intel64/bin'
     export LD_LIBRARY_PATH='/opt/HDF5/1.10.4/lib:/opt/intel/compilers_and_libraries_2018.3.222/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries_2018.3.222/linux/compiler/lib/intel64_lin:/opt/intel/compilers_and_libraries_2018.3.222/linux/mpi/intel64/lib:/opt/intel/compilers_and_libraries_2018.3.222/linux/mpi/mic/lib:/opt/intel/compilers_and_libraries_2018.3.222/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries_2018.3.222/linux/compiler/lib/intel64_lin:/opt/intel/compilers_and_libraries_2018.3.222/linux/mkl/lib/intel64_lin:/opt/intel/compilers_and_libraries_2018.3.222/linux/tbb/lib/intel64/gcc4.7:/opt/intel/compilers_and_libraries_2018.3.222/linux/tbb/lib/intel64/gcc4.7'
     export PATH="$PATH:$MPICCPATH"
-
+    export CFLAGS=$CFLAGS_FIX
+    
     . $ICCPATH/compilervars.sh intel64
     . $MPICCPATH/mpivars.sh
-    export CFLAGS=$CFLAGS_FIX
-    ${install_script} --enable-hdf5 -C $root_folder/CMakeScripts/intel.cmake -DHDF5_ROOT=/opt/HDF5/1.10.4
+    ${install_script} --enable-hdf5 -C $root_folder/CMakeScripts/intel.cmake --hdf5-path=/opt/HDF5/1.10.4
     ;;
 clang | Clang)
     export OMPI_MPICC=clang
@@ -50,6 +50,6 @@ pgi | PGI)
     export FC=pgfortran
     echo $PATH
     ls /opt/pgi/
-    ${install_script} --enable-hdf5 -DHDF5_ROOT=/opt/HDF5/1.10.4
+    ${install_script} --enable-hdf5 --hdf5-path=/opt/HDF5/1.10.4
     ;;
 esac

--- a/testing/tools/itf/src/list
+++ b/testing/tools/itf/src/list
@@ -28,7 +28,7 @@ itf_list_unwrap() {
     # itf_list_unwrap 'aarray' 'anykey' 'myarray'
     # echo ${!myarray[@]} # Should print 4
 
-    declare -nl pointer=$1
+    declare -n pointer=$1
     IFS="$_itf_sep" read -r -a $3 <<<"${pointer[$2]:1:-1}"
 }
 
@@ -45,7 +45,7 @@ itf_list_add() {
     # In any case, an item will be added to the list.
     # The items can be later retrieved as a bash array using itf_list_unwrap.
 
-    declare -nl pointer="$1"
+    declare -n pointer="$1"
     if [ -z "${pointer[$2]}" ]; then
         pointer["$2"]="${_itf_sep}${@:3}${_itf_sep}"
     else
@@ -64,7 +64,7 @@ itf_list_remove() {
     if [ $# -ne 3 ]; then
         return
     fi
-    declare -nl pointer="$1"
+    declare -n pointer="$1"
 
     # List is empty
     if [ -z "${pointer[$2]}" ]; then
@@ -72,7 +72,8 @@ itf_list_remove() {
     fi
 
     # Element not in the list
-    if [ $(itf_list_contains "$1" "$2" "$3") == 'false' ]; then
+    itf_list_contains "$1" "$2" "$3"
+    if [ $? -ne 0 ]; then
         return 0
     fi
 
@@ -103,17 +104,32 @@ itf_list_contains() {
     # $2: The associative array key
     # $3: The element to be found in an ITF-list string
 
-    declare -nl pointer=$1
+    declare -n pointer=$1
 
     # No items in the list or no sufficient parameters
     if [ -z "${pointer[$2]}" ] || [ $# -lt 3 ]; then
-        echo "false"
-        return 0
+        return 1
     fi
     # Check if substring exists
     if [ -z "${pointer[$2]##*${_itf_sep}$3${_itf_sep}*}" ]; then
-        echo 'true'
         return 0
     fi
-    echo 'false'
+    return 1
+}
+
+itf_array_contains() {
+    # Brief:
+    # Check if a bash array contains a given element
+    #
+    # Arguments:
+    # $1: The array variable name
+    # $2: The element value
+
+    if [ $# -lt 2 ]; then
+        return 2
+    fi
+
+    declare -n pointer=$1
+    case "${pointer[@]}" in *"${@:2}"*) return 0 ;; esac
+    return 1
 }

--- a/testing/tools/itf/src/test
+++ b/testing/tools/itf/src/test
@@ -10,7 +10,7 @@
 
 # onSuiteBegin   'suitename'        : before all test cases in the suite
 # onSuiteEnd     'suitename'        : after all test cases in the suite
-# onTestLoad     'testname'         : after loading the parametrized test cases
+# onTestLoad     'testname' 'ncases': after loading the parametrized test cases
 # onTestRunBegin 'testname' 'params': before a test case setup function
 # onTestRunEnd   'testname' 'params': after a test case teardown function
 # onTestPass     'message'          : after a test passes
@@ -28,20 +28,18 @@ itf_cfg['core:stdout']='/tmp/itf.out'
 # --------------------------- ITF Suite Public API ----------------------------
 
 itf_setup() {
+    # Brief:
     # Associate a setup function to a test function
     #
+    # Arguments:
+    # $1 - The test function name
+    # $2 - The teardown function name
+    #
     # Usage:
-    # itf_setup 'mytest' 'mysetup'
+    # itf_steup 'mytest' 'mysetup'
     #
-    # Explanation:
-    # Makes ITF call 'mysetup' before 'mytest' when executing test cases
-    #
-    # Use to:
-    # Express common steps for different tests without code duplication
-    #
-    # Example:
-    # itf_setup 'testOne' 'setupCommon'
-    # itf_setup 'testTwo' 'setupCommon'
+    # Details:
+    # ITF will call setup before each test case for the test function.
 
     if [ -z $1 ]; then
         echo '[ITF] Test function name cannot be empty' && exit 1
@@ -54,16 +52,18 @@ itf_setup() {
 }
 
 itf_teardown() {
+    # Brief:
     # Associate a teardown function to a test function
+    #
+    # Arguments:
+    # $1 - The test function name
+    # $2 - The teardown function name
     #
     # Usage:
     # itf_teardown 'mytest' 'myteardown'
     #
-    # Explanation:
-    # Makes ITF call 'mysetup' after 'myteardown' when executing test cases
-    #
-    # Use to:
-    # Express common steps for different tests without code duplication
+    # Details:
+    # ITF will call teardown after each test case for the test function.
     #
     # Example:
     # itf_teardown 'testOne' 'teardownCommon'
@@ -80,12 +80,13 @@ itf_teardown() {
 }
 
 itf_fixture() {
+    # Brief
     # Associate a setup and teardown function to a test function
     #
     # Usage:
     # itf_fixture 'mytest' 'mysetup' 'myteardown'
     #
-    # Explanation:
+    # Details:
     # See itf_setup and itf_teardown
     #
     # Example:
@@ -107,12 +108,12 @@ itf_case() {
     # Usage:
     # itf_case 'myfunction' '--arg1=val1' '--arg2=val2' ...
     #
-    # Explanation:
+    # Details:
     # Registers the 'myfunction' as a test function in ITF, if not already.
     # Then, saves the arguments for later usage to invoke the function.
     # This effectively creates a suite of cases for the specific test function.
     #
-    # Example
+    # Examples:
     # itf_case a_must_be_2 --a=2
     # itf_case a_must_be_3 --a=3
     # itf_case a_must_not_be_2 --a=3
@@ -124,15 +125,21 @@ itf_case() {
     fi
 
     # Check if the function name is in the blacklist
-    if [ $(itf_list_contains 'itf_filter' 'blacklist' "$1") == 'true' ]; then
-        return 0
+    if [ ! -z ${itf_filter['blacklist']} ]; then
+        # If this list is used, functions named here will not be registered
+        itf_list_contains 'itf_filter' 'blacklist' "$fullname"
+        if [ $? -eq 0 ]; then
+            return 0 # Ignore the test function
+        fi
     fi
 
     # Check if function name is in the whitelist
-    # If this list is used, only functions with names there may be called
-    if [ ! -z ${itf_filter['whitelist']} ] && \
-    [ $(itf_list_contains 'itf_filter' 'whitelist' "$fullname") == 'false' ]; then
-        return 0
+    if [ ! -z ${itf_filter['whitelist']} ]; then
+        # If this list is used, only functions with names there may be called
+        itf_list_contains 'itf_filter' 'whitelist' "$fullname"
+        if [ $? -ne 0 ]; then
+            return 0 # Ignore the test function
+        fi
     fi
 
     # Check if any argument assumes a value that should be ignored
@@ -143,14 +150,18 @@ itf_case() {
         local key=${k_prefix}${name}
 
         # Include list is not empty and does not match the parameter value
-        if [ ! -z ${itf_filter["include:$key"]} ] && \
-           [ $(itf_list_contains 'itf_filter' "include:$key" $value) == 'false' ]; then
-            return 0
+        if [ ! -z ${itf_filter["include:$key"]} ]; then
+            itf_list_contains 'itf_filter' "include:$key" $value
+            if [ $? -ne 0 ]; then
+                return 0 # Ignore the test case
+            fi
         fi
         # Exclude list is not empty and match the parameter value
-        if [ ! -z ${itf_filter["exclude:$key"]} ] && \
-           [ $(itf_list_contains 'itf_filter' "exclude:$key" $value) == 'true' ]; then
-            return 0
+        if [ ! -z ${itf_filter["exclude:$key"]} ]; then
+            itf_list_contains 'itf_filter' "exclude:$key" $value
+            if [ $? -eq 0 ]; then
+                return 0 # Ignore the test case
+            fi
         fi
     done
 
@@ -161,12 +172,16 @@ itf_case() {
 }
 
 itf_suite_unload() {
+    # Brief:
     # Register a function to be executed when the suite is finished.
     #
     # Parameters:
     # $1: A function name to clean up.
     #
     # Usage:
+    # itf_suite_unload 'my_suite_unload_function'
+    #
+    # Details:
     # This function is useful to clean up suite' extra variable and function names.
     # Keep in mind that ITF will automatically destroy test functions, setups and teardowns.
     # Use this function to register auxiliary functions and variables used to construct the suite.
@@ -176,35 +191,33 @@ itf_suite_unload() {
 
 # --------------------------- ITF Suite Private API ---------------------------
 
+# Brief:
 # Read-only associative array with status about the suite after execution
 #
-# Keys for the suite state:
+# Keys:
+# -- Suite --
+# suite_name: The fixture name
+# ntests: The test count in the suite
+# passed: The amount of tests that passed
+# failed: The amount of tests that failed
 #
-# - suite_name: The fixture name
-# - ntests: The test count in the suite
-# - passed: The amount of tests that passed
-# - failed: The amount of tests that failed
+# -- Individual Test Function --
+# [testname]_ntests: The test count for the specific function
+# [testname]_passed: The amount of tests that passed for a function
+# [testname]_failed: The amount of tests that failed for a function
 #
-# Keys for individual test function state:
-#
-# - [testname]_ntests: The test count for the specific function
-# - [testname]_passed: The amount of tests that passed for a function
-# - [testname]_failed: The amount of tests that failed for a function
-#
-# Internal ITF Array keys:
-#
-# - modules: The ITF modules loaded by this suite
+# -- Internal/Private Keys --
+# modules: The ITF modules loaded by this suite
 declare -A itf_state=()
 
-# Keys
+# Brief:
+# Filter parameters to prevent/allow test cases to be registered for execution
+#
+# Keys:
 # blacklist   - Ignore the test functions listed here (ITF list string)
 # whitelist   - Ignore all test functions not listed here (ITF list string)
 # include:suitename:testname:paramname - Test cases to include (ITF list string)
 # exclude:suitename:testname:paramname - Test cases to exclude (ITF list string)
-#
-# Details:
-# If include is empty, all tests are included
-# If exclude is empty, no tests are excluded
 declare -A itf_filter=()
 
 # Test case parameters
@@ -216,6 +229,16 @@ declare -A _itf_setup=()
 declare -A _itf_teardown=()
 
 itf_run_suite() {
+    # Brief:
+    # Interpret an ITF suite bash script and run all registered tests
+    #
+    # Parameters:
+    # $1 - The filename containing a suite of ITF tests
+    #
+    # Details:
+    # Clear the internal ITF engine state.
+    # Source the bash file, which should contain ITF function calls.
+    # Then, run every test case and issue ITF events for hook subscribers.
 
     # Clear ITF Suite variables state
     _itf_cases=()
@@ -247,11 +270,11 @@ itf_run_suite() {
 
         # Get an array of test cases associated with this test function name
         local tcases=()
+        local _ntests=${itf_state["${atest}_ntests"]}
         itf_list_unwrap '_itf_cases' "$atest" 'tcases'
-        itf_hook_publish 'onTestLoad' $atest
+        itf_hook_publish 'onTestLoad' "$atest" "$_ntests"
 
         # Iterate on every test case
-        local _ntests=${itf_state["${atest}_ntests"]}
         let _ntests=$_ntests-1
         for tid in $(seq 0 $_ntests); do
 

--- a/testing/tools/itf/testdriver/testdriver
+++ b/testing/tools/itf/testdriver/testdriver
@@ -6,9 +6,253 @@
 #   @author Alexandre de Limas Santana (alexandre.delimassantana@bsc.es)
 #   @date   May, 2020
 
+# Include ITF engine source code into the testdriver
 source $(dirname ${BASH_SOURCE[0]})/../src/itf
 
-# ---------------------------------- Colors -----------------------------------
+# ------------------ Test Runner State and Summary Variables ------------------
+
+# Brief:
+# Encapsulates dynamic data regarding loaded and executed suites and tests
+#
+# Details:
+# The driver state is used to keep track of progress through ITF event stream.
+# ITF publishes ordered events and we use this variable to buffer data.
+# This can be used in ITF hooks to print or account for test data.
+#
+# Keys:
+# -- Suite information --
+# suite.count: The amount of suites executed
+# suite.name: The currently loaded suite name
+#
+# -- Test information --
+# test.name: The currently loaded test function name
+# test.ncases: The test case count for the current loaded test function
+#
+# -- Case information --
+# case.id: A numeric identifier to the current loaded test case
+# case.params: string with the current case parameters in "key=val" format
+declare -A driver_state=()
+driver_state['suite.count']=0
+
+# Brief:
+# Variable to summarize all suites and test metrics gathered from execution
+#
+# Details:
+# Used to account for the statistics of the testdriver program after execution
+#
+# Keys:
+# ntests: The amount of tests cases executed.
+# passed: The amount of tests cases that passed.
+# failed: The amount of tests cases that failed.
+declare -A summary=()
+summary['ntests']=0
+summary['passed']=0
+summary['failed']=0
+
+# ------------------- Test Runner Failure Report Variables -------------------
+
+# Brief:
+# Test names with at least one failed test case
+#
+# Elements String Format:
+# suite_name.function_name
+declare -a failed_tests=()
+
+# Brief:
+# Associative array for full test name and its arguments for failed cases
+#
+# Keys Format:
+# suite_name.test_name: The fully qualified test name
+#
+# Value Format:
+# ITF list string with all parameters that failed for the test function
+#
+# Details:
+# Refer to itf/src/list for functions to manipulate ITF list strings.
+declare -A failed_cases=()
+
+# Example:
+# Assume that two suites ran, X and Y, and both have at least one failed case.
+# The failed cases comes from a function 'foo', in X, and 'bar', in 'Y'.
+# The parameters for 'foo' that caused the failure were 'a=1' and 'a=2'.
+# The parameters for 'bar' that caused the failure were 'a=3 b=4'.
+# In this case, the failure report variables must be:
+#
+# failed_tests=('X.foo' 'Y.bar')
+# failed_cases['X.foo']=',a=1,a=2,'
+# failed_cases['Y.bar']=',a=3 b=4,'
+
+# ------------------- Test Runner Argument Parsing Variables ------------------
+
+# Brief:
+# Holds key/value pairs regarding the testdriver additional behavior over ITF
+#
+# Details:
+# Use this variable to add new testdriver-specific configurations.
+# ITF engine configurations are directly handled in itf_cfg associative array
+#
+# Keys:
+# colors: boolean to disable color output in the terminal when set
+# fail_review: boolean to disable failed test name feedback after execution
+declare -A cfg=()
+cfg['colors']='true'
+cfg['fail_review']='true'
+
+# Brief:
+# Array of arguments passed to this program after argument parsing
+declare -a arguments=()
+
+print_help() {
+    # Brief:
+    # Prints usage guidelines and options to the standard output
+
+    echo "Usage:"
+    echo "./testdriver [OPTION]... [FILE]..."
+    echo ""
+    echo "Brief:"
+    echo "Execute ITF test cases in ITF suite files and generates a summary."
+    echo "ITF suites are bash scripts calling functions exposed by ITF."
+    echo "If no FILE argument is supplemented, no tests will be executed."
+    echo "The program returns zero only if all tests pass and at least one test is executed."
+    echo ""
+    echo "ITF Configuration Options:"
+    echo "  --path-modules [PATH]    Set the path to ITF modules loaded using itf_load_module."
+    echo "                               No path is selected by default."
+    echo "  --dry-run                Only count the number of tests but do not execute them."
+    echo "                               Use this option to test filter parameters."
+    echo "  -d, --maintain-ckpt-dir  Keep FTI checkpoint directories after running tests."
+    echo "                               ITF deletes directories after each test case by default."
+    echo "  --verbose                Enable test applications stdout to be displayed in terminal."
+    echo "                               The stdout will be always available in log files."
+    echo "  --quiet                  Disable all output form test cases in the terminal."
+    echo "                               The stdout will be always available in log files."
+    echo ""
+    echo "ITF Logging Options:"
+    echo "  --all-logs               Create logs for all test cases, regardless of their resolution."
+    echo "                               By default, only test cases that failed are logged."
+    echo "  --no-logs                Disable logs for all test cases, regardless of their resolution."
+    echo "                               By default, only test cases that failed are logged."
+    echo ""
+    echo "ITF Filtering Options:"
+    echo "  -i, --ignore [TESTNAME]  Ignore a test function contained in any suite file."
+    echo "                               By default, all functions with test cases will execute."
+    echo "                               This option can be used multiple times to ignore multiple tests."
+    echo "                               This option is incompatible with --pick."
+    echo "  -p, --pick   [TESTNAME]  Pick a test function from the suite files to execute."
+    echo "                               Using this option, all other test functions will be ignored."
+    echo "                               This option can be used multiple times to include multiple tests."
+    echo "                               This option is incompatible with --ignore."
+    echo "  -f, --filter [TARGS]     Ignore test cases from a given test function that match the test arguments."
+    echo "                               This option can be used multiple times for different tests and different arguments."
+    echo "  -r, --revfilter [TARGS]  Ignore test cases from a given test function that do not match the test arguments."
+    echo "                               This option can be used multiple times for different tests and different arguments."
+    echo ""
+    echo "  [TESTNAME]"
+    echo "        Format:  suite_name:test_name"
+    echo "        Example: recovername:standard"
+    echo ""
+    echo "  [TARGS]"
+    echo "        Format:   suite_name:test_name:param_name=val1[,val2]..."
+    echo "        Examples: recovername:standard:iolib=1"
+    echo "        Examples: recovername:standard:iolib=1,2,3"
+    echo ""
+    echo "Testdriver Options:"
+    echo "  --no-colors              Disable color for the testdriver output."
+    echo "                               By default, colors are turned on for terminal output."
+    echo "  --no-review              Disable exposing test case configurations that failed after execution."
+    echo "                               By default, test cases names and arguments that failed will be presented after execution."
+
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --path-modules)
+        itf_cfg['core:module_path']=$2
+        shift
+        shift
+        ;;
+    --no-colors)
+        cfg['colors']='false'
+        shift
+        ;;
+    --no-review)
+        cfg['fail_review']='false'
+        shift
+        ;;
+    --verbose)
+        itf_cfg['core:verbose']='true'
+        itf_cfg['fti:verbose']='true'
+        itf_cfg['fti:verbose_app']='true'
+        shift
+        ;;
+    --quiet)
+        itf_cfg['core:verbose']='false'
+        itf_cfg['fti:verbose']='false'
+        itf_cfg['fti:verbose_app']='false'
+        shift
+        ;;
+    --dry-run)
+        itf_cfg['core:dry_run']='true'
+        shift
+        ;;
+    --ignore | -i)
+        if [ ! -z ${itf_filter['whitelist']} ]; then
+            echo "Cannot use both --ignore and --pick test case filters"
+            exit 1
+        fi
+        itf_list_add 'itf_filter' 'blacklist' "$2"
+        shift
+        shift
+        ;;
+    --pick | -p)
+        if [ ! -z ${itf_filter['blacklist']} ]; then
+            echo "Cannot use both --ignore and --pick test case filters"
+            exit 1
+        fi
+        itf_list_add 'itf_filter' 'whitelist' "$2"
+        shift
+        shift
+        ;;
+    --filter | -f)
+        itf_list_add 'itf_filter' "exclude:${2%=*}" "${2#*=}"
+        shift
+        shift
+        ;;
+    --revfilter | -r)
+        itf_list_add 'itf_filter' "include:${2%=*}" "${2#*=}"
+        shift
+        shift
+        ;;
+    --all-logs)
+        itf_cfg['log:passed_cases']='true'
+        shift
+        ;;
+    --no-logs)
+        itf_cfg['log:passed_cases']='false'
+        itf_cfg['log:failed_cases']='false'
+        shift
+        ;;
+    -d | --maintain-ckpt-dir)
+        itf_cfg['fti:keep_ckpt_dir']='true'
+        shift
+        ;;
+    -h | --help)
+        print_help
+        exit 0
+        ;;
+    --*)
+        echo "Invalid option: $1"
+        echo "Use \"./$(basename $0) --help\" to see the correct usage options."
+        exit 1
+        ;;
+    *)
+        arguments+=($1)
+        shift
+        ;;
+    esac
+done
+
+# ------------------------ Test Runner Color Variables ------------------------
 
 declare -r COLOR_RESET='\033[0m'
 declare -r COLOR_WHITEBOLD='\033[1m\033[37m'
@@ -24,44 +268,69 @@ print_color() {
     # Parameters:
     # $1: The color to use
     # $2: The string to be printed
-    #
-    # Warning:
-    # If the string has spaces, the caller must use double quotes.
-    # ex.: print_color "This is my testname"
 
-    if [ ! -z ${cfg['no_colors']} ]; then
+    if [ ${cfg['colors']} == 'false' ]; then
         printf "%b" "${@:2}"
     else
         printf "$1${@:2}$COLOR_RESET"
     fi
 }
 
-# ---------------------------- ITF Hook Listeners -----------------------------
+# --------------------------- ITF Hook Registering ----------------------------
 
-declare -A driver_state=()
-driver_state['nsuites']=0
+# ITF engine hooks, parameter description and details are found in itf/src/test
+
+# Register to ITF events for when a suite is loaded/unloaded
+itf_hook_subscribe 'onSuiteBegin' 'suite_begin'
+itf_hook_subscribe 'onSuiteEnd' 'suite_end'
+
+# Register to ITF events for when a test function in a suite is loaded/unloaded
+itf_hook_subscribe 'onTestLoad' 'test_load'
+itf_hook_subscribe 'onTestRunBegin' 'test_case'
+
+# Register to ITF events for when a test finishes on success or failure
+itf_hook_subscribe 'onTestPass' 'test_pass'
+itf_hook_subscribe 'onTestFail' 'test_fail'
+
+# ------------------------ ITF Hook Listener Callbacks ------------------------
 
 suite_begin() {
+    # Brief:
+    # Print the suite name and account for its execution in the driver state
+    #
+    # Parameters:
+    # $1 - The suite name
+    #
+    # Details:
+    # This is called before executing the tests on a given suite
 
     # Give it a line feed if this is not the first suite
-    if [ ${driver_state['nsuites']} -gt 0 ]; then
+    if [ ${driver_state['suite.count']} -gt 0 ]; then
         echo ""
     fi
 
+    driver_state['suite.name']="$1"
     print_color $COLOR_WHITEBOLD "Suite: "
     print_color $COLOR_BLUEBOLD "$1"
     print_color $COLOR_WHITEBOLD " with "
     print_color $COLOR_YELLOWBOLD "${itf_state['ntests']}"
     print_color $COLOR_WHITEBOLD " tests.\n"
 
-    let driver_state['nsuites']=${driver_state['nsuites']}+1
+    let driver_state['suite.count']=${driver_state['suite.count']}+1
 }
 
 suite_end() {
+    # Brief:
+    # Print the suite summary and accumulate it into the overall summary
+    #
+    # Details:
+    # This is called after all test cases for a suite were executed
+
     let summary['ntests']=${summary['ntests']}+${itf_state[ntests]}
     let summary['passed']=${summary['passed']}+${itf_state[passed]}
     let summary['failed']=${summary['failed']}+${itf_state[failed]}
 
+    # If this is a dry run, we are not interested in suite-specific summary
     if [ ${itf_cfg['core:dry_run']} == 'true' ]; then
         return 0
     fi
@@ -73,23 +342,43 @@ suite_end() {
 }
 
 test_load() {
-    driver_state['test_name']="$1"
-    driver_state['test_id']=1
-    driver_state['test_max']=${itf_state["$1_ntests"]}
+    # Brief:
+    # Print the loaded test name and its parameters
+    #
+    # Parameters:
+    # $1 - The test function name
+    # $1 - The amount of test cases associated with this function
+    #
+    # Details:
+    # This is called before executing the first test cases of a test function
+
+    driver_state['test.name']="$1"
+    driver_state['case.id']=1
+    driver_state['test.ncases']="$2"
 
     print_color $COLOR_WHITEBOLD "\nFunction: "
-    print_color $COLOR_MAGENTABOLD "${driver_state['test_name']}"
+    print_color $COLOR_MAGENTABOLD "${driver_state['test.name']}"
     print_color $COLOR_WHITEBOLD " with "
-    print_color $COLOR_YELLOWBOLD "${driver_state['test_max']}"
+    print_color $COLOR_YELLOWBOLD "${driver_state['test.ncases']}"
     print_color $COLOR_WHITEBOLD " tests.\n\n"
 }
 
 test_case() {
-    print_color $COLOR_WHITEBOLD "+ Test "
-    print_color $COLOR_MAGENTABOLD "${itf_state[suite_name]}"
-    print_color $COLOR_WHITEBOLD ":${driver_state['test_name']} "
-    print_color $COLOR_WHITEBOLD "(${driver_state['test_id']}/${driver_state['test_max']}) "
+    # Brief:
+    # Print the loaded test name and its parameters
+    #
+    # Parameters:
+    # $1 - The test function name
+    #
+    # Details:
+    # This is called before executing the first test cases of a test function
 
+    print_color $COLOR_WHITEBOLD "+ Test "
+    print_color $COLOR_MAGENTABOLD "${driver_state['suite.name']}"
+    print_color $COLOR_WHITEBOLD ":${driver_state['test.name']} "
+    print_color $COLOR_WHITEBOLD "(${driver_state['case.id']}/${driver_state['test.ncases']}) "
+
+    driver_state['case.params']=""
     for param in ${@:2}; do
 
         local name=${param%=*}
@@ -98,9 +387,12 @@ test_case() {
 
         print_color $COLOR_BLUEBOLD "$name"
         print_color $COLOR_WHITEBOLD "=$val "
+        driver_state['case.params']=" ${driver_state['case.params']} $name=$val"
     done
     printf "\n"
-    let driver_state['test_id']=${driver_state['test_id']}+1
+
+    driver_state['case.params']="${driver_state['case.params']:2}"
+    let driver_state['case.id']=${driver_state['case.id']}+1
 }
 
 test_pass() {
@@ -129,148 +421,71 @@ test_fail() {
         done
     fi
     printf '\n'
+
+    local _sn="${driver_state['suite.name']}"
+    local _fn="${driver_state['test.name']}"
+    local _args="${driver_state['case.params']}"
+
+    # Register the test failure into the testdriver feedback variables
+    itf_array_contains 'failed_tests' "$_sn.$_fn"
+    if [ $? -ne 0 ]; then
+        failed_tests+=("$_sn.$_fn")
+    fi
+    echo $_args
+    itf_list_add 'failed_cases' "$_sn.$_fn" "$_args"
 }
-
-# --------------------------- ITF Hook Registering ----------------------------
-
-itf_hook_subscribe 'onSuiteBegin' 'suite_begin'
-itf_hook_subscribe 'onSuiteEnd' 'suite_end'
-
-itf_hook_subscribe 'onTestLoad' 'test_load'
-itf_hook_subscribe 'onTestRunBegin' 'test_case'
-
-itf_hook_subscribe 'onTestPass' 'test_pass'
-itf_hook_subscribe 'onTestFail' 'test_fail'
-
-# --------------------------- Test Runner Variables ---------------------------
-
-declare -A summary=()
-summary['ntests']=0
-summary['passed']=0
-summary['failed']=0
-
-declare -A cfg=()
-
-declare -a arguments=()
-# Parse the command line outputs, extracts the relevant and maintain the rest
-while [[ $# -gt 0 ]]; do
-    case $1 in
-    --path-modules)
-        # Set the path to where ITF modules will be
-        itf_cfg['core:module_path']=$2
-        shift
-        shift
-        ;;
-    --no-colors)
-        # Disable the color output for the test driver
-        cfg['no_colors']='true'
-        shift
-        ;;
-    --verbose)
-        # Activate all optional output from ITF and the FTI module
-        itf_cfg['core:verbose']='true'
-        itf_cfg['fti:verbose']='true'
-        itf_cfg['fti:verbose_app']='true'
-        shift
-        ;;
-    --quiet)
-        # Shutdown any output to the terminal derived from ITF
-        itf_cfg['core:verbose']='false'
-        itf_cfg['fti:verbose']='false'
-        itf_cfg['fti:verbose_app']='false'
-        shift
-        ;;
-    --dry-run)
-        # Only count the number of tests but do not execute them
-        itf_cfg['core:dry_run']='true'
-        shift
-        ;;
-    --ignore | -i)
-        # Ignores functions with the given name in a given suite
-        # Syntax is suite_name:function_name
-        # Example: -i dCP:standard will ignore the standard function in dCP
-        if [ ! -z ${itf_filter['whitelist']} ]; then
-            echo "Cannot use both --ignore and --pick test case filters"
-            exit 1
-        fi
-        itf_list_add 'itf_filter' 'blacklist' "$2"
-        shift
-        shift
-        ;;
-    --pick | -p)
-        # Only execte functions with the given name in a given suite
-        # Syntax is suite_name:function_name
-        # Example: --pick dCP:standard will run the standard function in dCP
-        if [ ! -z ${itf_filter['blacklist']} ]; then
-            echo "Cannot use both --ignore and --pick test case filters"
-            exit 1
-        fi
-        itf_list_add 'itf_filter' 'whitelist' "$2"
-        shift
-        shift
-        ;;
-    --filter | -f)
-        # Filters out test cases from a test function in a suite by its parameters
-        # Format: suite:test:param=v1,v2,v3
-        # Behavior: ITF ignores cases of 'test' function, in 'suite', where 'param' is v1, v2 or v3
-        itf_list_add 'itf_filter' "exclude:${2%=*}" "${2#*=}"
-        shift
-        shift
-        ;;
-    --revfilter | -r)
-        # Only run test cases from a test function in a suite by its parameters
-        # Format: suite:test:param=v1,v2,v3
-        # Behavior: ITF run only cases of 'test' function, in 'suite', where 'param' is v1, v2 or v3
-        # Details: revfilter is processed before filter
-        itf_list_add 'itf_filter' "include:${2%=*}" "${2#*=}"
-        shift
-        shift
-        ;;
-    --all-logs)
-        # Also keep the application logs for tests that passed
-        itf_cfg['log:passed_cases']='true'
-        shift
-        ;;
-    --no-logs)
-        # Do not keep any ITF logs
-        itf_cfg['log:passed_cases']='false'
-        itf_cfg['log:failed_cases']='false'
-        shift
-        ;;
-    -d | --maintain-ckpt-dir)
-        # Keep the FTI checkpoint, global and meta directories after execution
-        itf_cfg['fti:keep_ckpt_dir']='true'
-        shift
-        ;;
-    -h | --help)
-        # Prints a help message and exit
-        # TODO
-        exit 0
-        ;;
-    *)
-        arguments+=($1)
-        shift
-        ;;
-    esac
-done
 
 # --------------------------- Test Runner Procedure ---------------------------
 
+# Run all suites using ITF engine methods
+# ITF engine will generate hook events and invoke testrunner callback functions
 for suite in ${arguments[@]}; do
     itf_run_suite $suite
 done
 
+# Testrunner variables are filled with the results of ITF tests, ready to print
 if [ ${itf_cfg['core:dry_run']} == 'true' ]; then
+    # If execution was a dry run, only print total test count
     print_color $COLOR_WHITEBOLD "Total: "
     print_color $COLOR_YELLOWBOLD "${summary[ntests]}\n"
 elif [ ${#arguments[@]} -gt 1 ]; then
+    # If execution had more than one suite, print accumulated summary
     print_color $COLOR_WHITEBOLD "\n### Test Driver summary ###"
-    print_color $COLOR_WHITEBOLD "\nSuites:   ${driver_state['nsuites']}"
+    print_color $COLOR_WHITEBOLD "\nSuites:   ${driver_state['suite.count']}"
     print_color $COLOR_WHITEBOLD "\nTests:    ${summary[ntests]}"
     print_color $COLOR_GREENBOLD "\nPassed:   ${summary[passed]}"
     print_color $COLOR_REDBOLD "\nFailed:   ${summary[failed]}\n"
 fi
 
+if [ ${summary[failed]} -ne 0 ] && [ ${cfg['fail_review']} == "true" ]; then
+    # If execution had failed cases, report them after summary
+    print_color $COLOR_WHITEBOLD "\n### Failed Test Case Review ###"
+    for ft in ${failed_tests[@]}; do
+        # Print every failed test function
+        echo ""
+        print_color $COLOR_MAGENTABOLD "${ft%.*}"
+        print_color $COLOR_WHITEBOLD ".${ft#*.} ("
+        print_color $COLOR_YELLOWBOLD "${ft%.*}"
+        print_color $COLOR_YELLOWBOLD "${itf_cfg["log:failed_name"]}"
+        print_color $COLOR_WHITEBOLD ")\n"
+
+        declare -a ft_cases=()
+        itf_list_unwrap 'failed_cases' "$ft" 'ft_cases'
+        for ((i = 0; i < ${#ft_cases[@]}; i++)); do
+            # Print every failed test case for a given test function
+            print_color $COLOR_WHITEBOLD "+ "
+            for arg in ${ft_cases[$i]}; do
+                # Print every argument for the test case
+                print_color $COLOR_BLUEBOLD "${arg%=*}"
+                print_color $COLOR_WHITEBOLD "=${arg#*=} "
+            done
+            echo ""
+        done
+    done
+fi
+
 if [ ${summary[failed]} -ne 0 ] || [ ${summary[ntests]} -eq 0 ]; then
+    # If execution had failed cases or did not run tests, return non-zero
+    # Not executing tests should be regarded as a configuration fault or bug
     exit 1
 fi


### PR DESCRIPTION
- Added better comments to document functions in ITF scripts;

Reformatted the way information is expressed as well as how variables are named.
The idea is to make ITF bash scripts more appealing for python/C++ developers.

- Refactored ITF list functions to return integer values;

Bash functions cannot return explicit values, except for integers to denote the process return value.
ITF list functions were using 'echo' to return arbitrary strings that could be parsed by other commands.
This demands sub-shells, which has its own set of problems and is not ideal.
The new format is more concise to the way other bash commands like 'grep' and 'ls' works.
    
- Added an option to display the names and parameters for cases that failed after executing the ITF test driver;

This information was only available in logs or during execution.
Now, the test names and parameters are also summarized in the last lines outputted by the test driver.
Besides, the test driver points to the full log files by exposing the log file names.
This option is enabled by default and can be turned off with the "--no-review" argument.
    
- Added a help option for ITF test-driver to display user options.

The command showcases all options for configuring ITF, the test driver, filter functions and usage examples.