### PR TITLE
fixed breathe bug for RTD-sphinx

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,4 +4,5 @@ channels:
   - QuantStack 
 
 dependencies:
-  - breathe
+  - pip:
+    - breathe==4.19.1


### PR DESCRIPTION
Specified the latest version for breathe which RTD will be using to build the documentation. By default, RTD was using an older version in which a module has gone deprecated, causing an error during the build. 