### PR TITLE
Compilation suite bugfix and minor corrections when using gcc-10.1

### DIFF
--- a/testing/suites/compilation/cmake_versions.itf
+++ b/testing/suites/compilation/cmake_versions.itf
@@ -25,7 +25,7 @@ compile_fti() {
     echo "$($cmd --version)"
     check_equals "$($cmd --version | grep $version -c)" '1' "Could not validate CMake version $version"
 
-    $rootdir/install.sh
+    $rootdir/install.sh "--cmake-bin=$cmd"
 
     if [ ! -d "$libdir" ]; then
         echo "$libdir does not exist"

--- a/testing/suites/features/differentialCkpt/diff_test.h
+++ b/testing/suites/features/differentialCkpt/diff_test.h
@@ -91,7 +91,7 @@
 
 enum ALLOC_FLAGS { ALLOC_FULL, ALLOC_RANDOM };
 
-int grank;
+extern int grank;
 
 extern int numHeads;
 extern int finalTag;


### PR DESCRIPTION
- Installation script now returns non-zero when make or cmake fails as intended

The previous verion of the install script did not work as intended when instructions were piped.
In this scenario, it is necessary to use the BASH variable PIPESTATUS.

- Added external to the `granks' variable in diff_test.h

The old version failed to compile on gcc 10.1 as this rule is stricter in this version.

- Added the --cmake-bin option in the install script

This option enables compilation to happen with a custom cmake binary.
The ideia is that this command allows us to use, and test, this script in CI.
Also, It might help people using non-standard distributions of CMake.

- Compilation test suite now uses different CMake versions as intended

Previous test behavior did only check if the cmake binary existed.
When compiling, it used the system's default cmake installation.
Now the tests uses the new --cmake-bin option in the installation script.