### PR TITLE
Bundle of changes to address new docker image with code coverage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,19 @@ if(POLICY CMP0054)
 	cmake_policy(SET CMP0054 NEW)
 endif()
 
+option(ENABLE_FORTRAN "Enables the generation of the Fortran wrapper for FTI" OFF)
+option(ENABLE_EXAMPLES "Enables the generation of examples" ON)
+option(ENABLE_SIONLIB "Enables the parallel I/O SIONlib for FTI" OFF)
+option(ENABLE_HDF5 "Enables the HDF5 checkpoints for FTI" OFF)
+option(ENABLE_TESTS "Enables the generation of tests" ON)
+option(ENABLE_FI_IO "Enables the I/O failure injection mechanism" OFF)
+option(ENABLE_LUSTRE "Enables Lustre Support" OFF)
+option(ENABLE_DOCU "Enables the generation of a Doxygen documentation" OFF)
+option(ENABLE_TUTORIAL "Enables the generation of tutorial files" OFF)
+option(ENABLE_IME_NATIVE "Enables the IME native API" OFF)
+option(ENABLE_OPENSSL "Enables linking against system OpenSSL library" ON)
+option(ENABLE_COVERAGE "Enable another build, fti_cov, for gathering coverage metrics" OFF)
+
 if (ENABLE_GPU)
   if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     if( ${ENABLE_FORTRAN} )
@@ -90,18 +103,6 @@ if( ${ENABLE_FORTRAN} )
 endif()
 ## [END] DETERMINE COMPILER MAJOR VERSIONS
 
-option(ENABLE_FORTRAN "Enables the generation of the Fortran wrapper for FTI" OFF)
-option(ENABLE_EXAMPLES "Enables the generation of examples" ON)
-option(ENABLE_SIONLIB "Enables the parallel I/O SIONlib for FTI" OFF)
-option(ENABLE_HDF5 "Enables the HDF5 checkpoints for FTI" OFF)
-option(ENABLE_TESTS "Enables the generation of tests" ON)
-option(ENABLE_FI_IO "Enables the I/O failure injection mechanism" OFF)
-option(ENABLE_LUSTRE "Enables Lustre Support" OFF)
-option(ENABLE_DOCU "Enables the generation of a Doxygen documentation" OFF)
-option(ENABLE_TUTORIAL "Enables the generation of tutorial files" OFF)
-option(ENABLE_IME_NATIVE "Enables the IME native API" OFF)
-option(ENABLE_OPENSSL "Enables linking against system OpenSSL library" ON)
-
 set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS ON)
 
 include(GNUInstallDirs)
@@ -134,6 +135,12 @@ set(ADD_CFLAGS "${ADD_CFLAGS} -DHAVE_OPENSSL=${HAVE_OPENSSL}")
 
 if(ENABLE_LUSTRE)
     find_package(LUSTREAPI)
+endif()
+
+#PGCC C and C++ use builtin math functions, which are much more efficient than library calls.
+#http://www.cecalc.ula.ve/documentacion/tutoriales/HPF/pgiws_ug/pgi30u09.htm
+if(NOT "$ENV{COMPILER}" STREQUAL "pgi")
+	find_library(LIBM m DOC "The math library")
 endif()
 
 add_subdirectory(src/deps)
@@ -227,54 +234,59 @@ endif()
 
 set(ADD_CFLAGS "${ADD_CFLAGS} -D_FILE_OFFSET_BITS=64")
 
-if(${OPENSSL_FOUND})
-	add_library(fti.static STATIC ${SRC_FTI} ${SRC_CUDA_FTI} ${OPENSSL_LIBRARIES}
-    		$<TARGET_OBJECTS:iniparser> $<TARGET_OBJECTS:jerasure>)
-	add_library(fti.shared SHARED ${SRC_FTI} ${SRC_CUDA_FTI} ${OPENSSL_LIBRARIES}
-    		$<TARGET_OBJECTS:iniparser> $<TARGET_OBJECTS:jerasure>)
-    set(HAVE_OPENSSL 1)
-    #set(ADD_CFLAGS "${ADD_CFLAGS} -DHAVE_OPENSSL")
-else()
-	add_library(fti.static STATIC ${SRC_FTI} ${SRC_CUDA_FTI}
-	    $<TARGET_OBJECTS:iniparser> $<TARGET_OBJECTS:jerasure>
-		$<TARGET_OBJECTS:md5>)
-	add_library(fti.shared SHARED ${SRC_FTI} ${SRC_CUDA_FTI}
-	    $<TARGET_OBJECTS:iniparser> $<TARGET_OBJECTS:jerasure>
-		$<TARGET_OBJECTS:md5>)
-	set_property(TARGET fti.static fti.shared APPEND PROPERTY
-		LINK_FLAGS "-DMD5P=TRUE")
+set(fti_target_sources
+    ${SRC_FTI}
+    ${SRC_CUDA_FTI}
+    $<TARGET_OBJECTS:iniparser>
+    $<TARGET_OBJECTS:jerasure>
+)
+
+if(HAVE_OPENSSL)
+    list(APPEND fti_target_sources ${OPENSSL_LIBRARIES})
+endif()
+
+set(fti_targets "fti.static" "fti.shared")
+add_library("fti.static" STATIC ${fti_target_sources})
+add_library("fti.shared" SHARED ${fti_target_sources})
+set_property(TARGET ${fti_targets} PROPERTY OUTPUT_NAME "fti")
+
+# Links libraries as dependencies for all FTI targets
+function(link_to_fti)
+    message("Libraries: ${libraries}")
+    foreach(fti_target ${fti_targets})
+        target_link_libraries(${fti_target} ${ARGN})
+    endforeach(fti_target)
+endfunction(link_to_fti)
+
+# Coverage is only supported by the GCC compilers
+# TODO: Maybe support for CLang is also possible
+if(ENABLE_COVERAGE AND "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    set(ADD_CFLAGS "${ADD_CFLAGS} --coverage -O0 -g")
+    link_to_fti("gcov")
+endif()
+
+set_property(TARGET ${fti_targets} PROPERTY POSITION_INDEPENDENT_CODE True)
+set_property(TARGET ${fti_targets} APPEND PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
+
+link_to_fti(${MPI_C_LIBRARIES} ${LIBM} ${OPENSSL_LIBRARIES} ${CUDA_LIBRARIES})
+
+if(NOT HAVE_OPENSSL)
+    set_property(TARGET ${fti_target_sources} APPEND PROPERTY LINK_FLAGS "-DMD5P=TRUE")
 	unset(OPENSSL_LIBRARIES)
-    set(HAVE_OPENSSL 0)
-endif()
-set_target_properties(fti.static fti.shared PROPERTIES POSITION_INDEPENDENT_CODE True)
-
-if( NOT ZLIB_FOUND )
-    set_property(SOURCE ${SRC_CUDA_FTI} APPEND PROPERTY COMPILE_FLAGS "-DFTI_NOZLIB")
-endif()
-
-set_property(TARGET fti.static fti.shared APPEND PROPERTY LINK_FLAGS "${MPI_C_LINK_FLAGS}")
-set_property(TARGET fti.static fti.shared PROPERTY OUTPUT_NAME fti)
-
-#PGCC C and C++ use builtin math functions, which are much more efficient than library calls.
-#http://www.cecalc.ula.ve/documentacion/tutoriales/HPF/pgiws_ug/pgi30u09.htm
-if(NOT "$ENV{COMPILER}" STREQUAL "pgi")
-	find_library(LIBM m DOC "The math library")
 endif()
 
 if(ZLIB_FOUND)
-    target_link_libraries(fti.static ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}" "${ZLIB_LIBRARIES}" ${CUDA_LIBRARIES})
-    target_link_libraries(fti.shared ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}" "${ZLIB_LIBRARIES}" ${CUDA_LIBRARIES})
+    link_to_fti(${ZLIB_LIBRARIES})
 else()
-    target_link_libraries(fti.static ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}" ${CUDA_LIBRARIES})
-    target_link_libraries(fti.shared ${MPI_C_LIBRARIES} "${LIBM}" "${OPENSSL_LIBRARIES}" ${CUDA_LIBRARIES})
+    # TODO: COMPILER_FLAGS is superseded by COMPILER_OPTIONS (CMake 3.6+)
+    set_property(SOURCE ${SRC_CUDA_FTI} APPEND PROPERTY COMPILE_FLAGS "-DFTI_NOZLIB")
 endif()
 
 if(ENABLE_LUSTRE)
     if(LUSTREAPI_FOUND)
         include_directories(${LUSTREAPI_INCLUDE_DIRS})
         set_property(SOURCE ${SRC_FTI} APPEND PROPERTY COMPILE_DEFINITIONS LUSTRE)
-        target_link_libraries(fti.static ${LUSTREAPI_LIBRARIES})
-        target_link_libraries(fti.shared ${LUSTREAPI_LIBRARIES})
+        link_to_fti(${LUSTREAPI_LIBRARIES})
     else()
         message(WARNING "
   ** Lustre could not be found!
@@ -289,15 +301,14 @@ endif()
 if(ENABLE_SIONLIB)
     set(SIONLIBBASE "" CACHE FILEPATH "base path to SIONlib installation")
     set(SIONLIB_INCLUDE_DIR "${SIONLIBBASE}/include/")
-    include_directories("${SIONLIB_INCLUDE_DIR}")
+    include_directories(${SIONLIB_INCLUDE_DIR})
     set(SIONLIB_CFLAGS "-I${SIONLIB_INCLUDE_DIR} -DSION_DEBUG -D_SION_LINUX  -DSION_MPI")
     find_library(SIONLIB_MPI NAMES "sionmpi_64" PATHS ${SIONLIBBASE} PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
     find_library(SIONLIB_GEN NAMES "siongen_64" PATHS ${SIONLIBBASE} PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
     find_library(SIONLIB_SER NAMES "sionser_64" PATHS ${SIONLIBBASE} PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
     find_library(SIONLIB_COM NAMES "sioncom_64" PATHS ${SIONLIBBASE} PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
     find_library(SIONLIB_COM_LOCK NAMES "sioncom_64_lock_none" PATHS ${SIONLIBBASE} PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
-    target_link_libraries(fti.static "${SIONLIB_MPI}" "${SIONLIB_GEN}" "${SIONLIB_SER}" "${SIONLIB_COM}" "${SIONLIB_COM_LOCK}")
-    target_link_libraries(fti.shared "${SIONLIB_MPI}" "${SIONLIB_GEN}" "${SIONLIB_SER}" "${SIONLIB_COM}" "${SIONLIB_COM_LOCK}")
+    link_to_fti(${SIONLIB_MPI} ${SIONLIB_GEN} ${SIONLIB_SER} ${SIONLIB_COM} ${SIONLIB_COM_LOCK})
     add_definitions(-DENABLE_SIONLIB)
 endif()
 
@@ -311,8 +322,7 @@ if(ENABLE_IME_NATIVE)
     include_directories("${IMELIB_INCLUDE_DIR}")
     set(IMELIB_CFLAGS "-I${IMELIB_INCLUDE_DIR}")
     find_library(IMELIB NAMES "im_client" PATHS ${IMELIBBASE} PATH_SUFFIXES "lib" NO_DEFAULT_PATH)
-    target_link_libraries(fti.static "${IMELIB}")
-    target_link_libraries(fti.shared "${IMELIB}")
+    link_to_fti(${IMELIB})
     add_definitions(-DENABLE_IME_NATIVE)
 endif()
 
@@ -324,10 +334,8 @@ if(ENABLE_HDF5)
         include_directories(${HDF5_INCLUDE_DIRS})
         message("Here are the HDF5 include directories: ${HDF5_INCLUDE_DIRS}")
 		set_property(SOURCE ${SRC_FTI} APPEND PROPERTY COMPILE_DEFINITIONS HDF5)
-		target_link_libraries(fti.static ${HDF5_LIBRARIES})
-		target_link_libraries(fti.shared ${HDF5_LIBRARIES})
-		target_link_libraries(fti.static ${HDF5_HL_LIBRARIES})
-		target_link_libraries(fti.shared ${HDF5_HL_LIBRARIES})
+		link_to_fti(${HDF5_LIBRARIES})
+		link_to_fti(${HDF5_HL_LIBRARIES})
 	else()
 		message(WARNING "
 		** HDF5 could not be found!
@@ -341,9 +349,7 @@ if(ENABLE_FI_IO)
     add_definitions(-DENABLE_FTI_FI_IO)
 endif()
 
-set_property(SOURCE ${SRC_FTI} APPEND PROPERTY COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${SIONLIB_CFLAGS} ${ADD_CFLAGS}")
-
-install(TARGETS fti.static fti.shared DESTINATION "${CMAKE_INSTALL_LIBDIR}" EXPORT FTI_EXPORT
+install(TARGETS ${fti_targets} DESTINATION "${CMAKE_INSTALL_LIBDIR}" EXPORT FTI_EXPORT
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
@@ -380,7 +386,8 @@ if(ENABLE_FORTRAN)
 
 	set(SRC_FTI_F90 ${BPP_FTI_F90}
 		src/fortran/ftif.c)
-	set_property(SOURCE ${SRC_FTI_F90} APPEND PROPERTY COMPILE_FLAGS "${MPI_Fortran_COMPILE_FLAGS}")
+	set_property(SOURCE ${SRC_FTI_F90} APPEND
+		PROPERTY COMPILE_FLAGS "${MPI_Fortran_COMPILE_FLAGS}")
 
 	add_library(fti_f90.static STATIC ${SRC_FTI_F90})
 	add_dependencies(fti_f90.static bpp_file) # to serialize src generation
@@ -394,8 +401,8 @@ if(ENABLE_FORTRAN)
 	target_link_libraries(fti_f90.shared
 		fti.shared ${MPI_Fortran_LIBRARIES} ${MPI_C_LIBRARIES})
 
-    set_property(TARGET fti_f90.static fti_f90.shared APPEND PROPERTY
-        LINK_FLAGS "${MPI_Fortran_LINK_FLAGS} ${MPI_C_LINK_FLAGS}")
+	set_property(TARGET fti_f90.static fti_f90.shared APPEND
+		PROPERTY LINK_FLAGS "${MPI_Fortran_LINK_FLAGS} ${MPI_C_LINK_FLAGS}")
 	set_property(TARGET fti_f90.static fti_f90.shared
 		PROPERTY OUTPUT_NAME fti_f90)
 
@@ -408,6 +415,9 @@ if(ENABLE_FORTRAN)
 		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 	set_target_properties(fti_f90.static fti_f90.shared PROPERTIES POSITION_INDEPENDENT_CODE True)
 endif()
+
+# TODO: COMPILER_FLAGS is superseded by COMPILER_OPTIONS (CMake 3.6+)
+set_property(SOURCE ${SRC_FTI} PROPERTY COMPILE_FLAGS "${MPI_C_COMPILE_FLAGS} ${SIONLIB_CFLAGS} ${ADD_CFLAGS}")
 
 if(ENABLE_EXAMPLES)
 	add_subdirectory(examples)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ agent none
 
 stages {
   stage('Complation checks') {
-    agent { docker { image 'kellekai/archlinuxopenmpi1.10:stable' } }
+    agent { docker { image 'alexandrelimassantana/fti-development' } }
     steps { itf_suite('compilation') }
   }
   stage('GCC') {
@@ -47,7 +47,7 @@ stages {
   }
   stage('CLang') {
     when { expression { return env.BRANCH_NAME == 'master' } }
-    agent { docker { image 'kellekai/archlinuxopenmpi1.10:stable' } }
+    agent { docker { image 'alexandrelimassantana/fti-development' } }
     steps { script { compiler_checks('Clang') } }
   }
   stage('PGI') {

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,8 @@ print_usage() {
     echo "            [--ime-path=DIR]              # Path to DDN IME installation"
     echo "            [--cmake-bin=BIN]             # Use a custom CMake installation"
     echo " "
+    echo "            [--enable-coverage]           # Enable another build, fti_cov, for gathering coverage metrics"
+    echo "            [--make-verbose]              # Enable verbosity when calling make commands"
     echo "            [--debug]                     # Enable a debug build"
     echo "            [--silent]                    # No output to stdout or stderr during installation"
     echo "            [--uninstall]                 # No output to stdout or stderr during installation"
@@ -72,6 +74,10 @@ while [ $# -gt 0 ]; do
         ;;
     --debug)
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Debug"
+        shift # past argument=value
+        ;;
+    --enable-coverage)
+        CMAKE_ARGS="$CMAKE_ARGS -DENABLE_COVERAGE=1"
         shift # past argument=value
         ;;
     --enable-hdf5)
@@ -136,6 +142,10 @@ while [ $# -gt 0 ]; do
         ;;
     --cmake-bin=*)
         cmake_bin="${1#*=}"
+        shift
+        ;;
+    --make-verbose)
+        make_verbose="VERBOSE=1"
         shift
         ;;
     --silent)
@@ -203,13 +213,14 @@ else
         exit 1
     fi
 fi
+
 if [ $VERBOSE ]; then
-    make -j all install >>$install_log 2>&1
+    make -j $make_verbose all install >>$install_log 2>&1
     if [ $? -ne 0 ]; then
         exit 1
     fi
 else
-    make -j all install 2>&1 | tee -a $install_log
+    make -j $make_verbose all install 2>&1 | tee -a $install_log
     if [ ${PIPESTATUS[0]} -ne 0 ]; then
         exit 1
     fi

--- a/testing/suites/compilation/cmake_versions.itf
+++ b/testing/suites/compilation/cmake_versions.itf
@@ -17,7 +17,7 @@ compile_fti() {
 
     param_parse '+version' $@
 
-    local cmd="/opt/cmake/$version/bin/cmake"
+    local cmd="/opt/cmake/v${version}/bin/cmake"
     local libdir="$rootdir/install/lib" # Default name for the install script
 
     check_file_exists "$cmd" "CMake $version installation not found"
@@ -54,7 +54,7 @@ teardown() {
 # ------------------------- ITF Test Case Declaration -------------------------
 
 itf_fixture 'compile_fti' 'setup' 'teardown'
-supported=( '3.3' '3.4' '3.5' '3.6' '3.7' '3.8' '3.9' )
+supported=( '3.3.2' '3.4' '3.5' '3.7' '3.8' '3.9' '3.10' '3.11' '3.12' '3.13' '3.14' '3.15' '3.16' )
 
 for s in ${supported[@]}; do
     itf_case 'compile_fti' "--version=$s"

--- a/testing/tools/ci/build.sh
+++ b/testing/tools/ci/build.sh
@@ -19,7 +19,7 @@ fi
 
 case $1 in
 gcc | GCC)
-    ${install_script} --enable-hdf5 --enable-sionlib --sionlib-path=/opt/sionlib
+    ${install_script} --enable-coverage --enable-hdf5 --enable-sionlib --sionlib-path=/opt/sionlib
     ;;
 intel | Intel)
     export CFLAGS_FIX='-D__PURE_INTEL_C99_HEADERS__ -D_Float32=float -D_Float64=double -D_Float32x=_Float64 -D_Float64x=_Float128'

--- a/testing/tools/ci/coverage.sh
+++ b/testing/tools/ci/coverage.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#   Copyright (c) 2017 Leonardo A. Bautista-Gomez
+#   All rights reserved
+#
+#   @file   coverage.sh
+#   @author Alexandre de Limas Santana (alexandre.delimassantana@bsc.es)
+#   @date   June, 2020
+#
+#   @brief Aggregate coverage metrics in XML format to be used in Jenkins
+#   @arguments 
+#      output-format: The type of report to generate using gcovr.
+#   @details Must be called from the build directory
+
+case $1 in
+xml)
+    mkdir -p 'coverage'
+    gcovr --xml -r ../ -o 'coverage/summary.xml'
+    ;;
+hmtl)
+    mkdir -p 'coverage'
+    gcovr --html --html-details -r ../ -o 'coverage/index.html'
+    ;;
+*)
+    echo "Invalid output format"
+    ;;
+esac

--- a/testing/tools/ci/testdriver
+++ b/testing/tools/ci/testdriver
@@ -60,7 +60,6 @@ run)
     ${dirs['src']}/tools/itf/testdriver/testdriver \
         --path-modules "${dirs['compiled']}/itf/modules" \
         --filter recovername:standard:iolib=3 \
-        --filter standard:ckpt_disruption:expected=fail \
         ${arguments[@]}
     retval=$?
     unset MPIRUN_ARGS

--- a/testing/tools/ci/testdriver
+++ b/testing/tools/ci/testdriver
@@ -60,6 +60,7 @@ run)
     ${dirs['src']}/tools/itf/testdriver/testdriver \
         --path-modules "${dirs['compiled']}/itf/modules" \
         --filter recovername:standard:iolib=3 \
+        --filter standard:ckpt_disruption:expected=fail \
         ${arguments[@]}
     retval=$?
     unset MPIRUN_ARGS

--- a/testing/tools/itf/modules/fti
+++ b/testing/tools/itf/modules/fti
@@ -227,6 +227,7 @@ ckpt_disrupt_first() {
         local _dir="$(get_ckpt_dir $3 $_node)"
         local _f=$(ls $_dir | head -1)
         _f=${_f#*-}              # Remove the CkptXXX- prefix
+        _f=${_f%.*}              # Remove the file extension
         _files+=( "${_f//[^0-9]/}" ) # Extract the numbers
     done
     ckpt_disrupt $1 $2 $3 ${_files[@]}

--- a/testing/tools/itf/src/list
+++ b/testing/tools/itf/src/list
@@ -49,7 +49,7 @@ itf_list_add() {
     # TODO: As in bash 4.3.3, there is no need to use variable indirection.
     # It is possible to use 'declare -n pointer=$1' and avoid 'eval'.
     
-    if [ $# -lt 3 ]; then
+    if [ $# -lt 2 ]; then
         return 1
     fi
 


### PR DESCRIPTION
- CMake has been expanded with a new ENABLE_COVERAGE option;

This option links gcov and add compile flags to all FTI targets.
ENABLE_COVERAGE is disabled by default and only works when the compiler is GCC.
The new flags compute which lines of code have been executed in FTI.
Each application linked with FTI will contribute to these counters, making it perfect to use with current test suites.
    
- Added a new option, --enable-coverage, for the install script;
    
This option, disabled by default, sets the ENABLE_COVERAGE option during build.

- Added a new option, --make-verbose, for the install script --make-verbose;
    
This option sets the verbosity of the make command to true.
The best use for this option is to debug the build and installation procedure for FTI.
    
- Added the --enable-coverage option into the CI build script for the GCC compiler;
    
This change will make the CI environment be able to generate coverage metrics while executing the checks.
    
- Created a new testing tool program to generate xml coverage metrics;
    
- Changed CMakeList target_link_library usage to match CMake documentation;
    
The use of target_link_library does not include specifying multiple targets.
As such, it should be called once per target and not how it was being called.
The consequence was that FTI was being marked a dependency of FTI.
Although this was not proeminent on older versions of gcc, this is a problem on gcc-10.
    
- Adjusted the compilation test suite to test CMake versions 3.3.2 through 3.16;
    
- Re-introduced the possibility to include empty entries to an ITF string list;
    
This is necessary to keep track of test cases that have no arguments (i.e sync_intv).
    
- Bugfix on ITF functions for corrupting checkpoints for HDF5 IO;
    
The function now crop the file extension before using the rank number to match the files.
This process would fail on hdf5 checkpoints because HDF5 files contain numbers on the file extension (i.e .h5).