### PR TITLE
Feature datadefinition metadata

### DIFF
--- a/include/fti-intern.h
+++ b/include/fti-intern.h
@@ -641,6 +641,8 @@ extern "C" {
         int             ckptIntv;       /**< Ckpt. interval in minutes.     */
         int             lastCkptLvel;   /**< Last checkpoint level.         */
         int             wasLastOffline; /**< TRUE if last ckpt. offline.    */
+        int             basicTypesOffsetId; /**< offset id basic types      */
+        int             basicTypesNum;  /**< number of basic FTI types      */
         double          iterTime;       /**< Current wall time.             */
         double          lastIterTime;   /**< Time spent in the last iter.   */
         double          meanIterTime;   /**< Mean iteration time.           */
@@ -656,7 +658,7 @@ extern "C" {
         unsigned int    ckptId;         /**< Checkpoint ID.                 */
         unsigned int    ckptNext;       /**< Iteration for next checkpoint. */
         unsigned int    ckptLast;       /**< Iteration for last checkpoint. */
-        int32_t            ckptSize;       /**< Checkpoint size.               */
+        int32_t         ckptSize;       /**< Checkpoint size.               */
         unsigned int    nbVar;          /**< Number of protected variables. */
         unsigned int    nbVarStored;    /**< Nr. prot. var. stored in file  */
         unsigned int    nbType;         /**< Number of data types.          */

--- a/src/api.c
+++ b/src/api.c
@@ -136,7 +136,7 @@ int FTI_Init(const char* configFile, MPI_Comm globalComm) {
     }
     FTI_Try(FTI_InitGroupsAndTypes(&FTI_Exec),
       "malloc arrays for groups and types.");
-    FTI_Try(FTI_InitBasicTypes(), "create the basic data types.");
+    FTI_Try(FTI_InitBasicTypes(&FTI_Exec), "create the basic data types.");
     if (FTI_Topo.myRank == 0) {
         int restart = (FTI_Exec.reco != 3) ? FTI_Exec.reco : 0;
         FTI_Try(FTI_UpdateConf(&FTI_Conf, &FTI_Exec, restart),

--- a/src/meta.c
+++ b/src/meta.c
@@ -678,6 +678,7 @@ int FTI_WriteCkptMetaData(FTIT_configuration* FTI_Conf,
 int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int32_t* fs,
         int32_t mfs, char* fnl, char* checksums, int* allVarIDs,
+        int* allVarTypeIDs, int* allVarTypeSizes,
         int32_t* allVarSizes, uint32_t* allLayerSizes, char* allLayerHashes,
         int32_t *allVarPositions, char *allCharIds) {
     // no metadata files for FTI-FF
@@ -734,7 +735,17 @@ int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
             snprintf(key, FTI_BUFS, "%d:Var%d_id", i, j);
             snprintf(val, FTI_BUFS, "%d", allVarIDs[i * FTI_Exec->nbVar + j]);
             ini.set(&ini, key, val);
+            
+            // Save id of type
+            snprintf(key, FTI_BUFS, "%d:Var%d_typeId", i, j);
+            snprintf(val, FTI_BUFS, "%d", allVarTypeIDs[i * FTI_Exec->nbVar + j]);
+            ini.set(&ini, key, val);
 
+            // Save size of type
+            snprintf(key, FTI_BUFS, "%d:Var%d_typeSize", i, j);
+            snprintf(val, FTI_BUFS, "%d", allVarTypeSizes[i * FTI_Exec->nbVar + j]);
+            ini.set(&ini, key, val);
+            
             // Save size of variable
             snprintf(key, FTI_BUFS, "%d:Var%d_size", i, j);
             snprintf(val, FTI_BUFS, "%d",
@@ -900,6 +911,8 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     // Every process has the same number of protected variables
 
     int* allVarIDs = NULL;
+    int* allVarTypeIDs = NULL;
+    int* allVarTypeSizes = NULL;
     int32_t* allVarSizes = NULL;
     int32_t *allVarPositions = NULL;
 
@@ -913,6 +926,8 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     if (FTI_Topo->groupRank == 0) {
         allVarIDs = talloc(int, FTI_Topo->groupSize * FTI_Exec->nbVar);
+        allVarTypeIDs = talloc(int, FTI_Topo->groupSize * FTI_Exec->nbVar);
+        allVarTypeSizes = talloc(int, FTI_Topo->groupSize * FTI_Exec->nbVar);
         allVarSizes = talloc(int32_t, FTI_Topo->groupSize * FTI_Exec->nbVar);
         allVarPositions = talloc(int32_t,
          FTI_Topo->groupSize * FTI_Exec->nbVar);
@@ -927,6 +942,8 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     }
 
     int* myVarIDs = talloc(int, FTI_Exec->nbVar);
+    int* myVarTypeIDs = talloc(int, FTI_Exec->nbVar);
+    int* myVarTypeSizes = talloc(int, FTI_Exec->nbVar);
     int32_t* myVarSizes = talloc(int32_t, FTI_Exec->nbVar);
     int32_t* myVarPositions = talloc(int32_t, FTI_Exec->nbVar);
     char *ArrayOfStrings = (char *)malloc(FTI_Exec->nbVar *
@@ -936,7 +953,10 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     if (FTI_Data->data(&data, FTI_Exec->nbVar) != FTI_SCES) return FTI_NSCS;
 
     for (i = 0; i < FTI_Exec->nbVar; i++) {
+        int typeID = data[i].type->id - FTI_Exec->basicTypesOffsetId;
         myVarIDs[i] = data[i].id;
+        myVarTypeIDs[i] = (typeID < FTI_Exec->basicTypesNum) ? typeID : -1;
+        myVarTypeSizes[i] = data[i].type->size;
         myVarSizes[i] =  data[i].size;
         myVarPositions[i] = data[i].filePos;
         strncpy(&ArrayOfStrings[i*FTI_BUFS], data[i].idChar, FTI_BUFS);
@@ -944,6 +964,12 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     // Gather variables IDs
     MPI_Gather(myVarIDs, FTI_Exec->nbVar, MPI_INT, allVarIDs, FTI_Exec->nbVar,
+     MPI_INT, 0, FTI_Exec->groupComm);
+    // Gather variables Type IDs
+    MPI_Gather(myVarTypeIDs, FTI_Exec->nbVar, MPI_INT, allVarTypeIDs, FTI_Exec->nbVar,
+     MPI_INT, 0, FTI_Exec->groupComm);
+    // Gather variables IDs
+    MPI_Gather(myVarTypeSizes, FTI_Exec->nbVar, MPI_INT, allVarTypeSizes, FTI_Exec->nbVar,
      MPI_INT, 0, FTI_Exec->groupComm);
     // Gather variables sizes
     MPI_Gather(myVarSizes, FTI_Exec->nbVar, MPI_INT32_T, allVarSizes,
@@ -966,6 +992,8 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     }
 
     free(myVarIDs);
+    free(myVarTypeIDs);
+    free(myVarTypeSizes);
     free(myVarSizes);
     free(myVarPositions);
     free(ArrayOfStrings);
@@ -974,6 +1002,7 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     if (FTI_Topo->groupRank == 0) {
         int res = FTI_Try(FTI_WriteMetadata(FTI_Conf, FTI_Exec, FTI_Topo,
          FTI_Ckpt, fileSizes, mfs, ckptFileNames, checksums, allVarIDs,
+         allVarTypeIDs, allVarTypeSizes,
          allVarSizes, allLayerSizes, allLayerHashes, allVarPositions,
           allCharIds), "write the metadata.");
         free(allVarIDs);

--- a/src/meta.c
+++ b/src/meta.c
@@ -1006,6 +1006,8 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
          allVarSizes, allLayerSizes, allLayerHashes, allVarPositions,
           allCharIds), "write the metadata.");
         free(allVarIDs);
+	free(allVarTypeIDs);
+	free(allVarTypeSizes);
         free(allVarSizes);
         free(allCharIds);
         if (FTI_Ckpt[FTI_Exec->ckptMeta.level].isDcp) {

--- a/src/meta.h
+++ b/src/meta.h
@@ -28,6 +28,7 @@ int FTI_LoadMetaDataset(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 int FTI_WriteMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt, int32_t* fs,
         int32_t mfs, char* fnl, char* checksums, int* allVarIDs,
+        int* allVarTypeIDs, int* allVarTypeSizes,
         int32_t* allVarSizes, uint32_t* allLayerSizes, char* allLayerHashes,
         int32_t *allVarPositions, char *allCharIds);
 int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,

--- a/src/util/tools.c
+++ b/src/util/tools.c
@@ -313,7 +313,10 @@ void FTI_FreeTypesAndGroups(FTIT_execution* FTI_Exec) {
 
  **/
 /*-------------------------------------------------------------------------*/
-int FTI_InitBasicTypes() {
+int FTI_InitBasicTypes( FTIT_execution* FTI_Exec ) {
+
+    FTI_Exec->basicTypesOffsetId = FTI_Exec->nbType;
+
     FTI_InitType(&FTI_CHAR, sizeof(char));
     FTI_InitType(&FTI_SHRT, sizeof(int16_t));
     FTI_InitType(&FTI_INTG, sizeof(int));
@@ -325,6 +328,8 @@ int FTI_InitBasicTypes() {
     FTI_InitType(&FTI_SFLT, sizeof(float));
     FTI_InitType(&FTI_DBLE, sizeof(double));
     FTI_InitType(&FTI_LDBE, sizeof(long double));
+     
+    FTI_Exec->basicTypesNum = FTI_Exec->nbType - FTI_Exec->basicTypesOffsetId;
 
     return FTI_SCES;
 }

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -19,7 +19,7 @@ int FTI_VerifyChecksum(char* fileName, char* checksumToCmp);
 int FTI_Try(int result, char* message);
 void FTI_FreeTypesAndGroups(FTIT_execution* FTI_Exec);
 int FTI_InitGroupsAndTypes(FTIT_execution* FTI_Exec);
-int FTI_InitBasicTypes();
+int FTI_InitBasicTypes(FTIT_execution* FTI_Exec);
 int FTI_InitExecVars(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
         FTIT_topology* FTI_Topo, FTIT_checkpoint* FTI_Ckpt,
         FTIT_injection* FTI_Inje);


### PR DESCRIPTION
This PR adds information about the protected variable type to the metadata files.

It adds the type size and the type id to the files.

The type id maps to the FTI native types in the following way:

ID  | Type
----|----
-1  | self defined
0   | FTI_CHAR
1   | FTI_SHRT
2   | FTI_INTG
3   | FTI_LONG
4   | FTI_UCHR
5   | FTI_USHT
6   | FTI_UINT
7   | FTI_ULNG
8   | FTI_SFLT
9   | FTI_DBLE
10  | FTI_LDBE
