### PR TITLE
Added mappings from Fortran types to native C types when using HDF5 IO

### DIFF
--- a/src/fortran/ftif.c
+++ b/src/fortran/ftif.c
@@ -40,6 +40,12 @@
 #include "fti.h"
 #include "interface.h"
 #include "ftif.h"
+#include <ctype.h>
+#include <stdio.h>
+
+#define TYPECODE_NONE 0
+#define TYPECODE_INT 1
+#define TYPECODE_FLOAT 2
 
 /** @brief Fortran wrapper for FTI_Init, Initializes FTI.
  *
@@ -68,6 +74,87 @@ int FTI_Init_fort_wrapper(char* configFile, int* globalComm) {
 int FTI_InitType_wrapper(FTIT_type** type, int size) {
     *type = talloc(FTIT_type, 1);
     return FTI_InitType(*type, size);
+}
+
+/**
+ *   @brief      Initialize a FTIT_Type structure for a Fortran primitive type
+ *   @param      type            The data type to be intialized
+ *   @param      name            Fortran typename string
+ *   @param      size            Type size in bytes
+ *   @return     integer         FTI_SCES if successful
+ *
+ *   This method first try to associate the Fortran primitive type to a C type.
+ *   It does so by parsing the name and then the size of the data type.
+ *   If there is no direct correlation between C an Fortran, create a new type.
+ *
+ *   WARNING: We assume that C and Fortran types share the same binary format.
+ *   For instance, the C float is usually defined by the IEEE 754 format.
+ *   We would assume that Fortran real(4) types are also encoded as IEEE 754.
+ *   This is usually the case but might be an error source on some compilers.
+ **/
+int FTI_InitPrimitiveType_wrapper(FTIT_type** type, const char *name, int size)
+{
+    int typecode = TYPECODE_NONE;
+    char *dest;
+    int i = 0;
+    
+    // Copy the type name to lower case ignoring non-letters
+    dest  = talloc(char, strlen(name));
+    for (const char *p=name; *p; ++p) {
+      if((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z'))
+        dest[i++] = tolower(*p);
+    }
+    dest[i] = '\0';
+    // Discover the fundamental format behind the type name
+    if(strcmp(dest, "integer") == 0 ||
+      strcmp(dest, "logical") == 0 ||
+      strcmp(dest, "character") == 0)
+      typecode = TYPECODE_INT;
+    else if(strcmp(dest, "real") == 0)
+      typecode = TYPECODE_FLOAT;
+    free(dest);
+    // Find the static FTIT_Type object mapped to the primitive
+    switch (typecode)
+    {
+    case TYPECODE_INT:
+      switch (size)
+      {
+      case sizeof(char):
+        *type = &FTI_CHAR;
+        break;
+      case sizeof(short):
+        *type = &FTI_SHRT;
+        break;
+      case sizeof(int):
+        *type = &FTI_INTG;
+        break;
+      case sizeof(long):
+        *type = &FTI_LONG;
+        break;
+      default:
+        return FTI_InitType_wrapper(type, size);
+      }
+      break;
+    case TYPECODE_FLOAT:
+      switch (size)
+      {
+      case sizeof(float):
+        *type = &FTI_SFLT;
+        break;
+      case sizeof(double):
+        *type = &FTI_DBLE;
+        break;
+      case sizeof(long double):
+        *type = &FTI_LDBE;
+        break;
+      default:
+        return FTI_InitType_wrapper(type, size);
+      }
+      break;
+      default:
+        return FTI_InitType_wrapper(type, size);
+    }
+    return FTI_SCES;
 }
 
 /**

--- a/src/fortran/ftif.h
+++ b/src/fortran/ftif.h
@@ -43,6 +43,7 @@
 int FTI_Init_fort_wrapper(char* configFile, int* globalComm);
 int FTI_InitType_wrapper(FTIT_type** type, int size);
 int FTI_Protect_wrapper(int id, void* ptr, int32_t count, FTIT_type* type);
+int FTI_InitPrimitiveType_wrapper(FTIT_type** type, const char *name, int size);
 int FTI_InitComplexType_wrapper(FTIT_type** newType, FTIT_complexType* typeDefinition, int length, size_t size, char* name, FTIT_H5Group* parent);
 
 #endif

--- a/src/fortran/interface.F90.bpp
+++ b/src/fortran/interface.F90.bpp
@@ -126,6 +126,21 @@ module FTI
 
   endinterface
 
+  interface
+    function FTI_InitPrimitiveType_impl(type_F, name, size_F) &
+            bind(c, name='FTI_InitPrimitiveType_wrapper')
+
+      use ISO_C_BINDING
+
+      integer(c_int) :: FTI_InitPrimitiveType_impl
+      type(c_ptr), intent(OUT) :: type_F
+      character(c_char), intent(IN) :: name(*)
+      integer(c_int), value :: size_F
+
+    endfunction FTI_InitPrimitiveType_impl
+
+  endinterface
+
 	interface
 
 		function FTI_GetStoredSize_impl(id_F) &
@@ -396,7 +411,7 @@ contains
     endif
 
 !$SH for T in ${FORTTYPES}; do
-    call FTI_InitType($(fti_type ${T}), int($(fort_sizeof ${T})_C_int/8_c_int, C_int), err)
+    err = FTI_InitPrimitiveType($(fti_type ${T}), "${T}", int($(fort_sizeof ${T})_C_int/8_c_int, C_int))
     if (err /= FTI_SCES ) then
       return
     endif
@@ -463,6 +478,32 @@ contains
     err = int(FTI_InitType_impl(type_F%raw_type, int(size_F, c_int)))
 
   endsubroutine FTI_InitType
+
+  !>  Try to initialize an FTIT_Type from a Fortran primitive datatype.
+  !!  This function tries to map a Fortran primitive with a C primitive.
+  !!  If there is not a valid match, this will create a new custom datatype.
+  !!  \brief    Initializes a primitive data type in FTI.
+  !!  \param    type_F  (OUT)   The data type to be intialized.
+  !!  \param    name    (IN)    The Fortran data type mnemonic.
+  !!  \param    size_F  (IN)    The size of the data type in bytes.
+  !!  \return   integer         FTI_SCES if successful.
+  function FTI_InitPrimitiveType(type_F, name, size_F) result(ret)
+
+    type(FTI_type),   intent(OUT)   :: type_F
+    character(len=*), intent(IN)    :: name
+    integer,          intent(IN)    :: size_F
+    integer                         :: ret
+
+    character, target, dimension(1:len_trim(name)+1) :: name_c
+    integer :: ii, ll
+    ll = len_trim(name)
+    do ii = 1, ll
+      name_c(ii) = name(ii:ii)
+    enddo
+    name_c(ll+1) = c_null_char
+
+    ret = int(FTI_InitPrimitiveType_impl(type_F%raw_type, name_c, int(size_F, c_int)))
+  endfunction FTI_InitPrimitiveType
 
   !>  This function returns size of variable of given ID that is saved in metadata.
   !!  This may be different from size of variable that is in the program. If this


### PR DESCRIPTION
The solution is based on two steps, the bash pre-processor (BPP) and a initialization C function in the interface.
Upon compilation, BPP lists the datatypes supported by the compiler along with their size in bytes.
Then, BPP generate calls to a new C function in the Fortran interface wrapper, the FTI_InitPrimitiveType.
This function parses the Fortran datatype name and associate them to C datatype names (e.g. real may map to float/double/long double and integer may map to short/int/long).
The function uses sizeof() operations to check which relevant C type has the same size as its Fortran counterpart.
If a match is possible, FTI re-uses the FTIT_Type associated with that primitive.
Otherwise, a new custom FTIT_Type is created and therefore a new non-native HDF5 datatype.

Warning
The solution hereby proposed is based on the premise that both C and Fortran share a common binary format for similar datatypes.
That is, floating point datatypes should be in the IEEE 754 format and integer/logical datatypes should be in the two's complement format.
This should be the case on most compilers and systems.
However, if there is no such correlation, this feature will fail silently and store HDF5 checkpoints in respect to C-like datatypes.
A sympton of this problem is that Fortran applications recovering from checkpoints will have its data corrupted.