### PR TITLE
Fix #302: Added mappings from Fortran types to native C types 

### DIFF
--- a/docs/source/codeformatting.rst
+++ b/docs/source/codeformatting.rst
@@ -91,7 +91,7 @@ The checkers are easy to install if you have pip. For the latest installation st
 
 ..
 
-	To make use of the pre-commit hook, after cloning the repository, one should initialize their branch through ``git init`` command.
+	To make use of the pre-commit hook, after cloning the repository, one should initialize their branch through ``git init --template=.git-templates/`` command.
 
 ..
 

--- a/src/fortran/ftif.h
+++ b/src/fortran/ftif.h
@@ -43,6 +43,9 @@
 int FTI_Init_fort_wrapper(char* configFile, int* globalComm);
 int FTI_InitType_wrapper(FTIT_type** type, int size);
 int FTI_Protect_wrapper(int id, void* ptr, int32_t count, FTIT_type* type);
-int FTI_InitComplexType_wrapper(FTIT_type** newType, FTIT_complexType* typeDefinition, int length, size_t size, char* name, FTIT_H5Group* parent);
+int FTI_InitPrimitiveType_C(FTIT_type** type, const char *name, int size);
+int FTI_InitComplexType_wrapper(FTIT_type** newType,
+  FTIT_complexType* typeDefinition, int length, size_t size,
+  char* name, FTIT_H5Group* parent);
 
 #endif

--- a/src/fortran/interface.F90.bpp
+++ b/src/fortran/interface.F90.bpp
@@ -165,6 +165,21 @@ module FTI
 
   endinterface
 
+  interface
+    function FTI_InitPrimitiveType_impl(type_F, name, size_F) &
+            bind(c, name='FTI_InitPrimitiveType_C')
+
+      use ISO_C_BINDING
+
+      integer(c_int) :: FTI_InitPrimitiveType_impl
+      type(c_ptr), intent(OUT) :: type_F
+      character(c_char), intent(IN) :: name(*)
+      integer(c_int), value :: size_F
+
+    endfunction FTI_InitPrimitiveType_impl
+
+  endinterface
+
 	interface
 
 		function FTI_GetStoredSize_impl(id_F) &
@@ -435,7 +450,7 @@ contains
     endif
 
 !$SH for T in ${FORTTYPES}; do
-    call FTI_InitType($(fti_type ${T}), int($(fort_sizeof ${T})_C_int/8_c_int, C_int), err)
+    err = FTI_InitPrimitiveType($(fti_type ${T}), "${T}", int($(fort_sizeof ${T})_C_int/8_c_int, C_int))
     if (err /= FTI_SCES ) then
       return
     endif
@@ -582,6 +597,32 @@ contains
     err = int(FTI_InitType_impl(type_F%raw_type, int(size_F, c_int)))
 
   endsubroutine FTI_InitType
+
+  !>  Try to initialize an FTIT_Type from a Fortran primitive datatype.
+  !!  This function tries to map a Fortran primitive with a C primitive.
+  !!  If there is not a valid match, this will create a new custom datatype.
+  !!  \brief    Initializes a primitive data type in FTI.
+  !!  \param    type_F  (OUT)   The data type to be intialized.
+  !!  \param    name    (IN)    The Fortran data type mnemonic.
+  !!  \param    size_F  (IN)    The size of the data type in bytes.
+  !!  \return   integer         FTI_SCES if successful.
+  function FTI_InitPrimitiveType(type_F, name, size_F) result(ret)
+
+    type(FTI_type),   intent(OUT)   :: type_F
+    character(len=*), intent(IN)    :: name
+    integer,          intent(IN)    :: size_F
+    integer                         :: ret
+
+    character, target, dimension(1:len_trim(name)+1) :: name_c
+    integer :: ii, ll
+    ll = len_trim(name)
+    do ii = 1, ll
+      name_c(ii) = name(ii:ii)
+    enddo
+    name_c(ll+1) = c_null_char
+
+    ret = int(FTI_InitPrimitiveType_impl(type_F%raw_type, name_c, int(size_F, c_int)))
+  endfunction FTI_InitPrimitiveType
 
   !>  This function returns size of variable of given ID that is saved in metadata.
   !!  This may be different from size of variable that is in the program. If this


### PR DESCRIPTION
The solution is based on two steps, the bash pre-processor (BPP) and a initialization C function in the interface.
Upon compilation, BPP lists the datatypes supported by the compiler along with their size in bytes.
Then, BPP generate calls to a new C function in the Fortran interface wrapper, the FTI_InitPrimitiveType.
This function parses the Fortran datatype name and associate them to C datatype names (e.g. real may map to float/double/long double and integer may map to short/int/long).
The function uses sizeof() operations to check which relevant C type has the same size as its Fortran counterpart.
If a match is possible, FTI re-uses the FTIT_Type associated with that primitive.
Otherwise, a new custom FTIT_Type is created and therefore a new non-native HDF5 datatype.

Warning
The solution hereby proposed is based on the premise that both C and Fortran share a common binary format for similar datatypes.
That is, floating point datatypes should be in the IEEE 754 format and integer/logical datatypes should be in the two's complement format.
This should be the case on most compilers and systems.
However, if there is no such correlation, this feature will fail silently and store HDF5 checkpoints in respect to C-like datatypes.
A sympton of this problem is that Fortran applications recovering from checkpoints will have its data corrupted.