### PR TITLE
Added an uncoditional barrier in FTI_Finalize

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1075,8 +1075,8 @@ int FTI_Protect(int id, void* ptr, int32_t count, FTIT_type type) {
   representation. 
  **/
 /*-------------------------------------------------------------------------*/
-int FTI_SetAttribute( int id, FTIT_attribute attribute, FTIT_attributeFlag flag) {
-    
+int FTI_SetAttribute(int id, FTIT_attribute attribute,
+  FTIT_attributeFlag flag) {
     if (FTI_Exec.initSCES == 0) {
         FTI_Print("FTI is not initialized.", FTI_WARN);
         return FTI_NSCS;
@@ -1088,23 +1088,23 @@ int FTI_SetAttribute( int id, FTIT_attribute attribute, FTIT_attributeFlag flag)
         return FTI_NSCS;
     }
 
-    if( data == NULL ) {
+    if ( data == NULL ) {
         char str[FTI_BUFS];
-        snprintf( str, FTI_BUFS, "failed to set attribute: dataset with id=%d does not exist", id );
+        snprintf(str, FTI_BUFS,
+          "failed to set attribute: dataset with id=%d does not exist", id);
         FTI_Print(str, FTI_WARN);
         return FTI_NSCS;
     }
-    
-    if( (flag & FTI_ATTRIBUTE_NAME) == FTI_ATTRIBUTE_NAME ) {
-        strncpy( data->attribute.name, attribute.name, FTI_BUFS );     
+
+    if ( (flag & FTI_ATTRIBUTE_NAME) == FTI_ATTRIBUTE_NAME ) {
+        strncpy(data->attribute.name, attribute.name, FTI_BUFS);
     }
 
-    if( (flag & FTI_ATTRIBUTE_DIM) == FTI_ATTRIBUTE_DIM ) {
+    if ( (flag & FTI_ATTRIBUTE_DIM) == FTI_ATTRIBUTE_DIM ) {
         data->attribute.dim = attribute.dim;
     }
 
     return FTI_SCES;
-
 }
 
 /*-------------------------------------------------------------------------*/
@@ -2668,7 +2668,7 @@ int FTI_Finalize() {
         FTI_Print("FTI is not initialized.", FTI_WARN);
         return FTI_NSCS;
     }
-
+    MPI_Barrier(FTI_COMM_WORLD);
     if (FTI_Topo.amIaHead) {
         if ( FTI_Conf.stagingEnabled ) {
             FTI_FinalizeStage(&FTI_Exec, &FTI_Topo, &FTI_Conf);


### PR DESCRIPTION
This prevents ranks that already reached FTI_Finalize to start the cleanup.
Without this barrier, ranks could start cleaning up while other were still operating.
In fast applications, such as testing apps, this can lead to checkpoint recovery failures.
While some ranks are cleaning up checkpoint files, others would still be trying to load them into memory.