### PR TITLE
Patch of changes related to Fortran and FTIT_type object management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,26 +52,17 @@ if( ${ENABLE_FORTRAN} )
         endif()
 
         set(CMAKE_Fortran_FLAGS "-cpp")
-        try_run( PROG_RAN COMPILE_SUCCESS
-            "${CMAKE_BINARY_DIR}" "${VER_CHECK_SRC}"
-            RUN_OUTPUT_VARIABLE VER_STRING
-            )
+        try_run(PROG_RAN COMPILE_SUCCESS "${CMAKE_BINARY_DIR}" "${VER_CHECK_SRC}" RUN_OUTPUT_VARIABLE VER_STRING)
         if ( COMPILE_SUCCESS )
-            string( REGEX MATCH "[0-9]+"
-                DETECTED_VER "${VER_STRING}"
-                )
-
+            string( REGEX MATCH "[0-9]+" DETECTED_VER "${VER_STRING}")
             set( CMAKE_Fortran_COMPILER_VERSION_MAJOR "${DETECTED_VER}" )
-
             message(AUTHOR_WARNING "
             ** The major version was determined as: ${VER_STRING}")
         else()
-
             set(FORTRAN_VER_UNKNOWN 1)
             set(CMAKE_Fortran_COMPILER_VERSION_MAJOR "")
             message(AUTHOR_WARNING "
             ** The Fortran version could not be determined!")
-
         endif()
     else()
 

--- a/CMakeScripts/FindMPI.cmake
+++ b/CMakeScripts/FindMPI.cmake
@@ -472,8 +472,7 @@ function (interrogate_mpi_compiler lang try_libs)
     endif()
     if (${lang} STREQUAL Fortran)
       message(STATUS "Checking whether MPI Fortran module is available")
-      set(test_file "${CMAKE_BINARY_DIR}
-      ${CMAKE_FILES_DIRECTORY}/cmake_mpimodule_test.F90")
+      set(test_file "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/cmake_mpimodule_test.F90")
       file(WRITE "${test_file}" "
 program test_mpimodule
     use mpi

--- a/docs/source/apireference.rst
+++ b/docs/source/apireference.rst
@@ -16,6 +16,9 @@ APIs
 .. doxygenfunction:: FTI_InitType
 	:project: Fault Tolerance Library 
 
+.. doxygenfunction:: FTI_GetType
+	:project: Fault Tolerance Library 
+
 .. doxygenfunction:: FTI_InitComplexType
 	:project: Fault Tolerance Library 
 

--- a/examples/heatd2.c
+++ b/examples/heatd2.c
@@ -135,9 +135,9 @@ int main(int argc, char *argv[]) {
     // Define and initialize the datastructure
     cInfo myCkpt = {1, 1};
     // Create a new FTI data type
-    FTIT_type ckptInfo;
+    fti_id_t ckptInfo;
     // Initialize the new FTI data type
-    FTI_InitType(&ckptInfo, 2*sizeof(int));
+    ckptInfo = FTI_InitType(2*sizeof(int));
 
     FTI_Protect(0, &i, 1, FTI_INTG);
     FTI_Protect(1, &myCkpt, 1, ckptInfo);

--- a/include/fti-intern.h
+++ b/include/fti-intern.h
@@ -363,7 +363,7 @@ extern "C" {
      */
     typedef struct FTIT_type {
         int id;                              /**< ID of the data type.        */
-        int size;                            /**< Size of the data type.      */
+        size_t size;                         /**< Size of the data type.      */
         FTIT_complexType* structure;         /**< Logical structure for HDF5. */
         FTIT_H5Group* h5group;               /**< Group of this datatype.     */
 #ifdef ENABLE_HDF5

--- a/include/fti-intern.h
+++ b/include/fti-intern.h
@@ -406,7 +406,7 @@ extern "C" {
     typedef struct FTIT_typeField {
         FTIT_type *type;            /**< FTI type ID of the field.           */
         int id;                     /**< Order of the field in the structure */
-        int offset;                 /**< Offset of the field in structure.   */
+        size_t offset;              /**< Offset of the field in structure.   */
         int rank;                   /**< Field rank (max. 32)                */
         int dimLength[32];          /**< Lenght of each dimention            */
         char name[FTI_BUFS];        /**< Name of the field                   */

--- a/include/fti.h
+++ b/include/fti.h
@@ -37,6 +37,9 @@
 /** status 'not initialized' for stage requests                            */
 #define FTI_SI_NINI 0x0
 
+/** Identifier abstraction for FTI internal objects                        */
+#define fti_id_t int
+
 #include "fti-intern.h"
 
 #ifdef __cplusplus
@@ -51,27 +54,27 @@ extern "C" {
   extern MPI_Comm FTI_COMM_WORLD;
 
   /** FTI data type for chars.                                               */
-  extern FTIT_type FTI_CHAR;
+  extern fti_id_t FTI_CHAR;
   /** FTI data type for short integers.                                      */
-  extern FTIT_type FTI_SHRT;
+  extern fti_id_t FTI_SHRT;
   /** FTI data type for integers.                                            */
-  extern FTIT_type FTI_INTG;
+  extern fti_id_t FTI_INTG;
   /** FTI data type for long integers.                                       */
-  extern FTIT_type FTI_LONG;
+  extern fti_id_t FTI_LONG;
   /** FTI data type for unsigned chars.                                      */
-  extern FTIT_type FTI_UCHR;
+  extern fti_id_t FTI_UCHR;
   /** FTI data type for unsigned short integers.                             */
-  extern FTIT_type FTI_USHT;
+  extern fti_id_t FTI_USHT;
   /** FTI data type for unsigned integers.                                   */
-  extern FTIT_type FTI_UINT;
+  extern fti_id_t FTI_UINT;
   /** FTI data type for unsigned long integers.                              */
-  extern FTIT_type FTI_ULNG;
+  extern fti_id_t FTI_ULNG;
   /** FTI data type for single floating point.                               */
-  extern FTIT_type FTI_SFLT;
+  extern fti_id_t FTI_SFLT;
   /** FTI data type for double floating point.                               */
-  extern FTIT_type FTI_DBLE;
+  extern fti_id_t FTI_DBLE;
   /** FTI data type for long doble floating point.                           */
-  extern FTIT_type FTI_LDBE;
+  extern fti_id_t FTI_LDBE;
 
   /*---------------------------------------------------------------------------
     FTI public functions
@@ -79,23 +82,21 @@ extern "C" {
 
   int FTI_Init(const char *configFile, MPI_Comm globalComm);
   int FTI_Status();
-  int FTI_InitType(FTIT_type* type, int size);
-  int FTI_InitComplexType(FTIT_type* newType, FTIT_complexType* typeDefinition,
-   int length, size_t size, char* name, FTIT_H5Group* h5group);
-  void FTI_AddSimpleField(FTIT_complexType* typeDefinition, FTIT_type* ftiType,
-      size_t offset, int id, char* name);
-  void FTI_AddComplexField(FTIT_complexType* typeDefinition,
-   FTIT_type* ftiType, size_t offset, int rank, int* dimLength,
-   int id, char* name);
+  int FTI_InitType(int size);
+  FTIT_type* FTI_GetType(fti_id_t id);
+  fti_id_t FTI_InitComplexType(char* name, int size, FTIT_H5Group* h5group);
+  int FTI_AddSimpleField(fti_id_t id, char* name, fti_id_t tid, size_t offset);
+  int FTI_AddComplexField(fti_id_t id, char* name,
+    fti_id_t tid, size_t offset, int ndims, int* dim_size);
   int FTI_InitGroup(FTIT_H5Group* h5group, char* name, FTIT_H5Group* parent);
   int FTI_RenameGroup(FTIT_H5Group* h5group, char* name);
-  int FTI_Protect(int id, void* ptr, int32_t count, FTIT_type type);
+  int FTI_Protect(int id, void* ptr, int32_t count, fti_id_t tid);
   int FTI_SetAttribute(int id, FTIT_attribute attribute,
           FTIT_attributeFlag flag);
   int FTI_DefineDataset(int id, int rank, int* dimLength, char* name,
    FTIT_H5Group* h5group);
   int FTI_DefineGlobalDataset(int id, int rank, FTIT_hsize_t* dimLength,
-   const char* name, FTIT_H5Group* h5group, FTIT_type type);
+   const char* name, FTIT_H5Group* h5group, fti_id_t tid);
   int FTI_AddSubset(int id, int rank, FTIT_hsize_t* offset,
    FTIT_hsize_t* count, int did);
   int FTI_RecoverDatasetDimension(int did);
@@ -126,7 +127,6 @@ extern "C" {
    MPI_Comm globalComm);
   int FTI_RecoverVarInit();
   int FTI_RecoverVarFinalize();
-
 
 #ifdef __cplusplus
 }

--- a/include/fti.h
+++ b/include/fti.h
@@ -82,9 +82,9 @@ extern "C" {
 
   int FTI_Init(const char *configFile, MPI_Comm globalComm);
   int FTI_Status();
-  int FTI_InitType(int size);
+  int FTI_InitType(size_t size);
   FTIT_type* FTI_GetType(fti_id_t id);
-  fti_id_t FTI_InitComplexType(char* name, int size, FTIT_H5Group* h5group);
+  fti_id_t FTI_InitComplexType(char* name, size_t size, FTIT_H5Group* h5group);
   int FTI_AddSimpleField(fti_id_t id, char* name, fti_id_t tid, size_t offset);
   int FTI_AddComplexField(fti_id_t id, char* name,
     fti_id_t tid, size_t offset, int ndims, int* dim_size);

--- a/src/IO/hdf5-fti.c
+++ b/src/IO/hdf5-fti.c
@@ -83,7 +83,6 @@ int FTI_ActivateHeadsHDF5(FTIT_configuration* FTI_Conf,
  **/
 /*-------------------------------------------------------------------------*/
 void FTI_CreateComplexType(FTIT_type* ftiType) {
-    // TODO(alex): check documentation
     char str[FTI_BUFS];
 
     // Sanity Checks
@@ -94,9 +93,8 @@ void FTI_CreateComplexType(FTIT_type* ftiType) {
         FTI_Print(str, FTI_DBUG);
         return;
     }
-
     // If type is simple (i.e initialized with FTI_InitType)
-    if (ftiType->structure == NULL) {
+    if (!FTI_IsTypeComplex(ftiType)) {
         snprintf(str, sizeof(str), "Creating type [%d] as array of bytes.",
          ftiType->id);
         FTI_Print(str, FTI_DBUG);
@@ -104,7 +102,6 @@ void FTI_CreateComplexType(FTIT_type* ftiType) {
         H5Tset_size(ftiType->h5datatype, ftiType->size);
         return;
     }
-
     // If type is complex (i.e initialized with FTI_InitComplexType)
     hid_t partTypes[FTI_BUFS];
     int i;
@@ -143,7 +140,6 @@ void FTI_CreateComplexType(FTIT_type* ftiType) {
             }
         }
     }
-
     // create new HDF5 compound datatype
     snprintf(str, sizeof(str), "Creating type [%d].", ftiType->id);
     FTI_Print(str, FTI_DBUG);
@@ -154,7 +150,6 @@ void FTI_CreateComplexType(FTIT_type* ftiType) {
     if (ftiType->h5datatype < 0) {
         FTI_Print("FTI failed to create HDF5 type.", FTI_WARN);
     }
-
     // inserting component fields into compound datatype
     for (i = 0; i < ftiType->structure->length; i++) {
         snprintf(str, sizeof(str), "Insering type [%d] into new type [%d].",

--- a/src/IO/hdf5-fti.h
+++ b/src/IO/hdf5-fti.h
@@ -37,8 +37,8 @@ int FTI_ScanGroup(hid_t gid, char* fn);
 int FTI_CheckDimensions(FTIT_keymap * FTI_Data, FTIT_execution * FTI_Exec);
 void FTI_FreeVPRMem(FTIT_execution* FTI_Exec, FTIT_keymap* FTI_Data);
 herr_t FTI_WriteSharedFileData(FTIT_dataset FTI_Data);
-void FTI_CreateComplexType(FTIT_type* ftiType, FTIT_type** FTI_Type);
-void FTI_CloseComplexType(FTIT_type* ftiType, FTIT_type** FTI_Type);
+void FTI_CreateComplexType(FTIT_type* ftiType);
+void FTI_CloseComplexType(FTIT_type* ftiType);
 void FTI_CreateGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup,
  FTIT_H5Group** FTI_Group);
 void FTI_OpenGroup(FTIT_H5Group* ftiGroup, hid_t parentGroup,

--- a/src/api.c
+++ b/src/api.c
@@ -346,8 +346,6 @@ fti_id_t FTI_InitComplexType(char* name, size_t size, FTIT_H5Group* h5group) {
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_AddSimpleField(fti_id_t id, char* name, fti_id_t fid, size_t offset) {
-    // TODO(alex): These errors must be catastrophic
-    // TODO(alex): use constant on warning message
     FTIT_type *struct_ref, *field_type;
     int field_id;
     FTIT_typeField *field;
@@ -370,7 +368,7 @@ int FTI_AddSimpleField(fti_id_t id, char* name, fti_id_t fid, size_t offset) {
     }
     if (field_id > TYPES_FIELDS_MAX) {
         FTI_Print(
-          "Complex type must contain at most 256 fields.",
+          "Complex type must contain at most " STR(TYPES_FIELDS_MAX) "fields.",
           FTI_WARN);
         return FTI_NSCS;
     }
@@ -407,9 +405,6 @@ int FTI_AddSimpleField(fti_id_t id, char* name, fti_id_t fid, size_t offset) {
 /*-------------------------------------------------------------------------*/
 int FTI_AddComplexField(fti_id_t id, char* name,
   fti_id_t tid, size_t offset, int ndims, int* dim_size) {
-    // TODO(alex): These errors should be catastrophic
-    // TODO(alex): use constant in warning message
-    // TODO(alex): use memcpy on dim_size
     FTIT_complexType *type;
     FTIT_typeField *field;
     int i;
@@ -423,7 +418,8 @@ int FTI_AddComplexField(fti_id_t id, char* name,
     }
     if (ndims < 1 || ndims > TYPES_DIMENSION_MAX) {
         FTI_Print(
-          "Complex type field must have between 1 and 32 dimensions",
+          "Complex type field must have between 1 and "
+          STR(TYPES_DIMENSION_MAX) " dimensions",
           FTI_WARN);
         return FTI_NSCS;
     }
@@ -442,8 +438,7 @@ int FTI_AddComplexField(fti_id_t id, char* name,
     field = &type->field[type->length-1];  // Length was inc by AddSimpleField
     // Complex Field initialization
     field->rank = ndims;
-    for (i = 0; i < ndims; i++)
-        field->dimLength[i] = dim_size[i];
+    memcpy(field->dimLength, dim_size, ndims*sizeof(int));
     return FTI_SCES;
 }
 

--- a/src/api.c
+++ b/src/api.c
@@ -36,6 +36,7 @@
  *  @brief  API functions for the FTI library.
  */
 
+#include <stdarg.h> //TODO:(alex) maybe functions that use this move!!
 
 #include "interface.h"
 #include "IO/cuda-md5/md5Opt.h"
@@ -66,29 +67,27 @@ static FTIT_injection FTI_Inje;
 MPI_Comm FTI_COMM_WORLD;
 
 /** FTI data type for chars.                                               */
-FTIT_type FTI_CHAR;
+fti_id_t FTI_CHAR;
 /** FTI data type for short integers.                                      */
-FTIT_type FTI_SHRT;
+fti_id_t FTI_SHRT;
 /** FTI data type for integers.                                            */
-FTIT_type FTI_INTG;
+fti_id_t FTI_INTG;
 /** FTI data type for long integers.                                       */
-FTIT_type FTI_LONG;
+fti_id_t FTI_LONG;
 /** FTI data type for unsigned chars.                                      */
-FTIT_type FTI_UCHR;
+fti_id_t FTI_UCHR;
 /** FTI data type for unsigned short integers.                             */
-FTIT_type FTI_USHT;
+fti_id_t FTI_USHT;
 /** FTI data type for unsigned integers.                                   */
-FTIT_type FTI_UINT;
+fti_id_t FTI_UINT;
 /** FTI data type for unsigned long integers.                              */
-FTIT_type FTI_ULNG;
+fti_id_t FTI_ULNG;
 /** FTI data type for single floating point.                               */
-FTIT_type FTI_SFLT;
+fti_id_t FTI_SFLT;
 /** FTI data type for double floating point.                               */
-FTIT_type FTI_DBLE;
+fti_id_t FTI_DBLE;
 /** FTI data type for long doble floating point.                           */
-FTIT_type FTI_LDBE;
-
-
+fti_id_t FTI_LDBE;
 
 /*-------------------------------------------------------------------------*/
 /**
@@ -136,7 +135,6 @@ int FTI_Init(const char* configFile, MPI_Comm globalComm) {
     }
     FTI_Try(FTI_InitGroupsAndTypes(&FTI_Exec),
       "malloc arrays for groups and types.");
-    FTI_Try(FTI_InitBasicTypes(&FTI_Exec), "create the basic data types.");
     if (FTI_Topo.myRank == 0) {
         int restart = (FTI_Exec.reco != 3) ? FTI_Exec.reco : 0;
         FTI_Try(FTI_UpdateConf(&FTI_Conf, &FTI_Exec, restart),
@@ -239,219 +237,208 @@ int FTI_Status() {
 
 /*-------------------------------------------------------------------------*/
 /**
-  @brief      It initializes a data type.
-  @param      type            The data type to be intialized.
-  @param      size            The size of the data type to be intialized.
-  @return     integer         FTI_SCES if successful.
+  @brief      Registers a new data type in FTI runtime
+  @param      size             The size of the data type.
+  @return     fti_id_t         An external handle to represent the new type.
 
-  This function initalizes a data type. The only information needed is the
-  size of the data type, the rest is black box for FTI. Types saved as byte array
-  in case of HDF5 format.
+  This function initalizes a data type.
+  The type is treated as a black box for FTI.
+  Thus, the runtime only requires information about its size.
+  Types built this was are saved as byte array when using HDF5 format.
 
- **/
+**/
 /*-------------------------------------------------------------------------*/
-int FTI_InitType(FTIT_type* type, int size) {
-    type->id = FTI_Exec.nbType;
+fti_id_t FTI_InitType(int size) {
+    FTIT_type *type;
+
+    // Sanity Check
+    if (size < 1) {
+        FTI_Print("Types must have positive size", FTI_WARN);
+        return FTI_NSCS;
+    }
+    if (FTI_Exec.datatypes.ntypes >= TYPES_MAX) {
+        FTI_Print("Maximum number of datatypes reached", FTI_WARN);
+        return FTI_NSCS;
+    }
+    // Type initialization
+    type = FTI_GetType(FTI_Exec.datatypes.ntypes);
+    type->id = FTI_Exec.datatypes.ntypes;
     type->size = size;
     type->structure = NULL;
-
 #ifdef ENABLE_HDF5
     type->h5group = FTI_Exec.H5groups[0];
-
-    // Maps FTI types to HDF5 types
-    switch (FTI_Exec.nbType) {
-        case 0:
-            type->h5datatype = H5T_NATIVE_CHAR; break;
-        case 1:
-            type->h5datatype = H5T_NATIVE_SHORT; break;
-        case 2:
-            type->h5datatype = H5T_NATIVE_INT; break;
-        case 3:
-            type->h5datatype = H5T_NATIVE_LONG; break;
-        case 4:
-            type->h5datatype = H5T_NATIVE_UCHAR; break;
-        case 5:
-            type->h5datatype = H5T_NATIVE_USHORT; break;
-        case 6:
-            type->h5datatype = H5T_NATIVE_UINT; break;
-        case 7:
-            type->h5datatype = H5T_NATIVE_ULONG; break;
-        case 8:
-            type->h5datatype = H5T_NATIVE_FLOAT; break;
-        case 9:
-            type->h5datatype = H5T_NATIVE_DOUBLE; break;
-        case 10:
-            type->h5datatype = H5T_NATIVE_LDOUBLE; break;
-        default:
-            type->h5datatype = -1; break;  // to mark as closed
-    }
+    type->h5datatype = -1;  // to mark as closed
 #endif
+    // Global structure update
+    FTI_Exec.datatypes.ntypes += 1;
+    return type->id;
+}
 
-    // make a clone of the type in case the user won't store pointer
-    FTI_Exec.FTI_Type[FTI_Exec.nbType] = malloc(sizeof(FTIT_type));
-    *FTI_Exec.FTI_Type[FTI_Exec.nbType] = *type;
+/*-------------------------------------------------------------------------*/
+/**
+  @brief      Obtains the FTIT_type associated to a given type handle
+  @param      handle         The data type handle
+  @return     FTIT_type      An external handle to represent the new type
 
-    FTI_Exec.nbType = FTI_Exec.nbType + 1;
+  Returns NULL if the handle is not associated to an initialized complex type.
 
+**/
+/*-------------------------------------------------------------------------*/
+inline FTIT_type* FTI_GetType(fti_id_t id) {
+    // TODO(alex): Place this in a better spot, this function is lib-private
+    return &FTI_Exec.datatypes.types[id];
+}
+
+
+/*-------------------------------------------------------------------------*/
+/**
+  @brief      Initializes an empty complex data type.
+  @param      name            An optional type name
+  @param      size            The total size of the complex data type
+  @param      h5group         An optional H5 group identifier
+  @return     fti_id_t        An external handle to represent the new type.
+
+  Creates a complex data type that serves as a container for other data types.
+  The components can be added using FTI_AddSimpleField and FTI_AddComplexField.
+
+**/
+/*-------------------------------------------------------------------------*/
+fti_id_t FTI_InitComplexType(char* name, int size, FTIT_H5Group* h5group) {
+    FTIT_type *type;
+    FTIT_complexType *structure;
+    int type_id;
+
+    // Sanity check
+    TRY_ALLOC(structure, FTIT_complexType, 1) {
+        return FTI_NSCS;
+    }
+    // Simple type initialization
+    type_id = FTI_InitType(size);
+    type = FTI_GetType(type_id);
+    // Complex type initialization
+    if (h5group)
+        type->h5group = FTI_Exec.H5groups[h5group->id];
+    type->structure = structure;
+    FTI_CopyStringOrDefault(type->structure->name, name, "Type%d", type_id);
+    return type_id;
+}
+
+/*-------------------------------------------------------------------------*/
+/**
+  @brief      Adds a simple type as a complex data type component.
+  @param      id              The complex data type handle
+  @param      name            The field name
+  @param      fid             The field data type handle
+  @param      offset          Offset of the field (use offsetof)
+  @return     integer         FTI_SCES when successful, FTI_NSCS otherwise
+
+  Adds a scalar field to a complex data type at a given offset.
+  Do note that FTI does not check for memory boundaries within the data type.
+  Specifying a wrong offset leads to undefined behavior.
+  This can be avoided using the offsetof() macro.
+
+ **/
+/*-------------------------------------------------------------------------*/
+int FTI_AddSimpleField(fti_id_t id, char* name, fti_id_t fid, size_t offset) {
+    // TODO(alex): These errors must be catastrophic
+    // TODO(alex): use constant on warning message
+    FTIT_type *struct_ref, *field_type;
+    int field_id;
+    FTIT_typeField *field;
+
+    struct_ref = FTI_GetComplexType(id);
+    field_type = FTI_GetType(fid);
+    // Sanity Checks
+    if (struct_ref == NULL) {
+        FTI_Print(
+          "Complex type id invalid when attempting to add a field",
+          FTI_WARN);
+        return FTI_NSCS;
+    }
+    field_id = struct_ref->structure->length;
+    if (field_type == NULL) {
+        FTI_Print(
+          "Complex field type id invalid when attempting to add a field",
+          FTI_WARN);
+        return FTI_NSCS;
+    }
+    if (field_id > TYPES_FIELDS_MAX) {
+        FTI_Print(
+          "Complex type must contain at most 256 fields.",
+          FTI_WARN);
+        return FTI_NSCS;
+    }
+    // Field Initialization
+    field = &struct_ref->structure->field[field_id];
+    field->id = field_id;
+    field->type = field_type;
+    field->offset = offset;
+    FTI_CopyStringOrDefault(field->name, name, "T%d", id);
+    field->rank = 1;
+    field->dimLength[0] = 1;
+    // Structure update
+    struct_ref->structure->length++;
     return FTI_SCES;
 }
 
 /*-------------------------------------------------------------------------*/
 /**
-  @brief      It initializes a complex data type.
-  @param      newType         The data type to be intialized.
-  @param      typeDefinition  Structure definition of the new type.
-  @param      length          Number of fields in structure
-  @param      size            Size of the structure.
-  @param      name            Name of the structure.
-  @param      h5group         Group of the type.
-  @return     integer         FTI_SCES if successful.
+  @brief      Adds a complex field to a complex data type.
+  @param      id              The complex data type handle
+  @param      name            The field name
+  @param      fid             The field data type handle
+  @param      offset          Offset of the field (use offsetof)
+  @param      ndims           The number of dimensions for the field
+  @param      dim_size        Array of lengths for each dimension
+  @return     integer         FTI_SCES when successful, FTI_NSCS otherwise
 
-  This function initalizes a simple data type. New type can only consists
-  fields of flat FTI types (no arrays). Type definition must include:
-  - length                => number of fields in the new type
-  - field[].type          => types of the field in the new type
-  - field[].name          => name of the field in the new type
-  - field[].rank          => number of dimentions of the field
-  - field[].dimLength[]   => length of each dimention of the field
+  Adds an N-dimensional array field to a complex data type at a given offset.
+  Do note that FTI does not check for memory boundaries within the data type.
+  Specifying a wrong offset leads to undefined behavior.
+  This can be avoided using the offsetof() macro.
 
  **/
 /*-------------------------------------------------------------------------*/
-int FTI_InitComplexType(FTIT_type* newType, FTIT_complexType* typeDefinition,
- int length, size_t size, char* name, FTIT_H5Group* h5group) {
-    if (h5group == NULL) {
-        h5group = FTI_Exec.H5groups[0];
-    }
-    if (length < 1) {
-        FTI_Print("Type can't contain less than 1 type.", FTI_WARN);
-        return FTI_NSCS;
-    }
-    if (length > 255) {
-        FTI_Print("Type can't contain more than 255 types.", FTI_WARN);
-        return FTI_NSCS;
-    }
+int FTI_AddComplexField(fti_id_t id, char* name,
+  fti_id_t tid, size_t offset, int ndims, int* dim_size) {
+    // TODO(alex): These errors should be catastrophic
+    // TODO(alex): use constant in warning message
+    // TODO(alex): use memcpy on dim_size
+    FTIT_complexType *type;
+    FTIT_typeField *field;
     int i;
-    for (i = 0; i < length; i++) {
-        if (typeDefinition->field[i].rank < 1) {
-            FTI_Print("Type rank must be greater than 0.", FTI_WARN);
+
+    // Sanity Check
+    if (dim_size == NULL) {
+        FTI_Print(
+          "Complex type field dimension size pointer cannot be NULL.",
+          FTI_WARN);
+        return FTI_NSCS;
+    }
+    if (ndims < 1 || ndims > TYPES_DIMENSION_MAX) {
+        FTI_Print(
+          "Complex type field must have between 1 and 32 dimensions",
+          FTI_WARN);
+        return FTI_NSCS;
+    }
+    for (i = 0; i < ndims; i++) {
+        if (dim_size[i] < 1) {
+            FTI_Print(
+              "Complex type must have positive dimension sizes.",
+              FTI_WARN);
             return FTI_NSCS;
         }
-        if (typeDefinition->field[i].rank > 32) {
-            FTI_Print("Maximum rank is 32.", FTI_WARN);
-            return FTI_NSCS;
-        }
-        int j;
-        for (j = 0; j < typeDefinition->field[i].rank; j++) {
-            if (typeDefinition->field[i].dimLength[j] < 1) {
-                char str[FTI_BUFS];
-                snprintf(str, FTI_BUFS, "(%s, index: %d) Type dimention length"
-                " must be greater than 0.", typeDefinition->field[i].name, i);
-                FTI_Print(str, FTI_WARN);
-                return FTI_NSCS;
-            }
-        }
     }
-
-    newType->id = FTI_Exec.nbType;
-    newType->size = size;
-    // assign type definition to type structure
-    // (types, names, ranks, dimLengths)
-    typeDefinition->length = length;
-    if (name == NULL || !strlen(name)) {
-        // sprintf(typeDefinition->name, "Type%d", newType->id);
-        snprintf(typeDefinition->name, sizeof(typeDefinition->name),
-         "Type%d", newType->id);
-    } else {
-        strncpy(typeDefinition->name, name, FTI_BUFS);
-    }
-
-#ifdef ENABLE_HDF5
-    newType->h5datatype = -1;  // to mark as closed
-    newType->h5group = FTI_Exec.H5groups[h5group->id];
-#endif
-
-    // make a clone of the type definition in case the user won't store pointer
-    newType->structure = malloc(sizeof(FTIT_complexType));
-    *newType->structure = *typeDefinition;
-
-    // append a space for new type
-    FTI_Exec.FTI_Type = realloc(FTI_Exec.FTI_Type,
-      sizeof(FTIT_type*) * (FTI_Exec.nbType + 1));
-
-    // make a clone of the type in case the user won't store pointer
-    FTI_Exec.FTI_Type[FTI_Exec.nbType] = malloc(sizeof(FTIT_type));
-    *FTI_Exec.FTI_Type[FTI_Exec.nbType] = *newType;
-
-    FTI_Exec.nbType = FTI_Exec.nbType + 1;
-
+    // Simple Field initialization
+    if (FTI_AddSimpleField(id, name, tid, offset) == FTI_NSCS)
+      return FTI_NSCS;
+    type = FTI_GetComplexType(id)->structure;
+    field = &type->field[type->length-1];  // Length was inc by AddSimpleField
+    // Complex Field initialization
+    field->rank = ndims;
+    for (i = 0; i < ndims; i++)
+        field->dimLength[i] = dim_size[i];
     return FTI_SCES;
-}
-
-/*-------------------------------------------------------------------------*/
-/**
-  @brief      It adds a simple field in complex data type.
-  @param      typeDefinition  Structure definition of the complex data type.
-  @param      ftiType         Type of the field
-  @param      offset          Offset of the field (use offsetof)
-  @param      id              Id of the field (start with 0)
-  @param      name            Name of the field (put NULL if want default)
-  @return     integer         FTI_SCES if successful.
-
-  This function adds a field to the complex datatype. Use offsetof macro to
-  set offset. First ID must be 0, next one must be +1. If name is NULL FTI
-  will set "T${id}" name. Sets rank and dimLength to 1.
-
- **/
-/*-------------------------------------------------------------------------*/
-void FTI_AddSimpleField(FTIT_complexType* typeDefinition, FTIT_type* ftiType,
- size_t offset, int id, char* name) {
-    typeDefinition->field[id].typeID = ftiType->id;
-    typeDefinition->field[id].offset = offset;
-    if (name == NULL || !strlen(name)) {
-        // sprintf(typeDefinition->field[id].name, "T%d", id);
-        snprintf(typeDefinition->field[id].name,
-          sizeof(typeDefinition->field[id].name), "T%d", id);
-    } else {
-        strncpy(typeDefinition->field[id].name, name, FTI_BUFS);
-    }
-    typeDefinition->field[id].rank = 1;
-    typeDefinition->field[id].dimLength[0] = 1;
-}
-
-/*-------------------------------------------------------------------------*/
-/**
-  @brief      It adds a simple field in complex data type.
-  @param      typeDefinition  Structure definition of the complex data type.
-  @param      ftiType         Type of the field
-  @param      offset          Offset of the field (use offsetof)
-  @param      rank            Rank of the array
-  @param      dimLength       Dimention length for each rank
-  @param      id              Id of the field (start with 0)
-  @param      name            Name of the field (put NULL if want default)
-  @return     integer         FTI_SCES if successful.
-
-  This function adds a field to the complex datatype. Use offsetof macro to
-  set offset. First ID must be 0, next one must be +1. If name is NULL FTI
-  will set "T${id}" name.
-
- **/
-/*-------------------------------------------------------------------------*/
-void FTI_AddComplexField(FTIT_complexType* typeDefinition, FTIT_type* ftiType,
-  size_t offset, int rank, int* dimLength, int id, char* name) {
-    typeDefinition->field[id].typeID = ftiType->id;
-    typeDefinition->field[id].offset = offset;
-    typeDefinition->field[id].rank = rank;
-    int i;
-    for (i = 0; i < rank; i++) {
-        typeDefinition->field[id].dimLength[i] = dimLength[i];
-    }
-    if (name == NULL || !strlen(name)) {
-        // sprintf(typeDefinition->field[id].name, "T%d", id);
-        snprintf(typeDefinition->field[id].name,
-          sizeof(typeDefinition->field[id].name), "T%d", id);
-    } else {
-        strncpy(typeDefinition->field[id].name, name, FTI_BUFS);
-    }
 }
 
 /*-------------------------------------------------------------------------*/
@@ -776,7 +763,7 @@ int FTI_RenameGroup(FTIT_H5Group* h5group, char* name) {
   @param      id              ID for searches and update.
   @param      ptr             Pointer to the data structure.
   @param      count           Number of elements in the data structure.
-  @param      type            Type of elements in the data structure.
+  @param      tid             The data type handle for the variable
   @return     integer         FTI_SCES if successful.
 
   This function stores a pointer to a data structure, its size, its ID,
@@ -788,7 +775,7 @@ int FTI_RenameGroup(FTIT_H5Group* h5group, char* name) {
 
  **/
 /*-------------------------------------------------------------------------*/
-int FTI_Protect(int id, void* ptr, int32_t count, FTIT_type type) {
+int FTI_Protect(int id, void* ptr, int32_t count, fti_id_t tid) {
     if (FTI_Exec.initSCES == 0) {
         FTI_Print("FTI is not initialized.", FTI_WARN);
         return FTI_NSCS;
@@ -849,12 +836,12 @@ int FTI_Protect(int id, void* ptr, int32_t count, FTIT_type type) {
         data->ptr = ptr;
 #endif
         data->count = count;
-        data->type = FTI_Exec.FTI_Type[type.id];
-        data->eleSize = type.size;
-        data->size = type.size * count;
+        data->type = FTI_GetType(tid);
+        data->eleSize = data->type->size;
+        data->size = data->type->size * count;
         data->dimLength[0] = count;
         FTI_Exec.ckptSize = FTI_Exec.ckptSize +
-        ((type.size * count) - prevSize);
+        ((data->type->size * count) - prevSize);
         if (strlen(data->idChar) == 0) {
             /*sprintf(str, "Variable ID %d reseted. (Stored In %s).  
             Current ckpt. size per rank is %.2fMB.", id, memLocation, 
@@ -983,15 +970,19 @@ int FTI_Protect(int id, void* ptr, int32_t count, FTIT_type type) {
     // Important assignment, we use realloc!
     data->sharedData.dataset = NULL;
     data->count = count;
-    data->type = FTI_Exec.FTI_Type[type.id];
-    data->eleSize = type.size;
-    data->size = type.size * count;
+    data->type = FTI_GetType(tid);
+    if (data->type == NULL) {
+      //TODO:(alex) handle error?
+      exit(1);
+    }
+    data->eleSize = data->type->size;
+    data->size = data->type->size * count;
     data->rank = 1;
     data->dimLength[0] = data->count;
     data->h5group = FTI_Exec.H5groups[0];
     // sprintf(data->name, "Dataset_%d", id);
     snprintf(data->name, sizeof(data->name), "Dataset_%d", id);
-    FTI_Exec.ckptSize = FTI_Exec.ckptSize + (type.size * count);
+    FTI_Exec.ckptSize = FTI_Exec.ckptSize + (data->type->size * count);
 
     if (FTI_Conf.dcpPosix) {
         if (!(data->isDevicePtr)) {
@@ -1116,7 +1107,7 @@ int FTI_SetAttribute(int id, FTIT_attribute attribute,
   @param      dimLength       Dimention length for each rank.
   @param      name            Name of the dataset in HDF5 file.
   @param      h5group         Group of the dataset. If Null then "/".
-  @param      type            FTI type of the dataset.
+  @param      tid             FTI Data type handler 
   @return     integer         FTI_SCES if successful.
 
   This function defines a global dataset which is shared among all ranks.
@@ -1127,7 +1118,7 @@ int FTI_SetAttribute(int id, FTIT_attribute attribute,
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_DefineGlobalDataset(int id, int rank, FTIT_hsize_t* dimLength,
- const char* name, FTIT_H5Group* h5group, FTIT_type type) {
+ const char* name, FTIT_H5Group* h5group, fti_id_t tid) {
 #ifdef ENABLE_HDF5
     FTIT_globalDataset* last = FTI_Exec.globalDatasets;
 
@@ -1165,7 +1156,7 @@ int FTI_DefineGlobalDataset(int id, int rank, FTIT_hsize_t* dimLength,
     last->name[FTI_BUFS-1] = '\0';
     last->numSubSets = 0;
     last->varId = NULL;
-    last->type = type;
+    last->type = FTI_GetType(tid);
     last->location = (h5group) ?
      FTI_Exec.H5groups[h5group->id] : FTI_Exec.H5groups[0];
 
@@ -3047,37 +3038,45 @@ int FTI_RecoverVarFinalize() {
  **/
 /*-------------------------------------------------------------------------*/
 void FTI_Print(char* msg, int priority) {
-    if (priority >= FTI_Conf.verbosity) {
-        if (msg != NULL) {
-            switch (priority) {
-                case FTI_EROR:
-                    fprintf(stderr, "[ " FTI_COLOR_RED
-                     "FTI Error - %06d" FTI_COLOR_RESET " ] : %s : %s \n",
-                      FTI_Topo.myRank, msg, strerror(errno));
-                    break;
-                case FTI_WARN:
-                    fprintf(stdout, "[ " FTI_COLOR_ORG
-                     "FTI Warning %06d" FTI_COLOR_RESET " ] : %s \n",
-                      FTI_Topo.myRank, msg);
-                    break;
-                case FTI_INFO:
-                    if (FTI_Topo.splitRank == 0) {
-                        fprintf(stdout, "[ " FTI_COLOR_GRN
-                         "FTI  Information" FTI_COLOR_RESET " ] : %s \n", msg);
-                    }
-                    break;
-                case FTI_IDCP:
-                    if (FTI_Topo.splitRank == 0) {
-                        fprintf(stdout, "[ " FTI_COLOR_BLU
-                         "FTI  dCP Message" FTI_COLOR_RESET " ] : %s \n", msg);
-                    }
-                    break;
-                case FTI_DBUG:
-                    fprintf(stdout, "[FTI Debug - %06d] : %s \n",
-                     FTI_Topo.myRank, msg);
-                    break;
+    FILE *stream = stdout;
+
+    // Sanity Checks
+    if (priority < FTI_Conf.verbosity)
+        return;
+    if (msg == NULL)
+      return;
+
+    // Decide the stream
+    if (priority == FTI_EROR)
+      stream = stderr;
+
+    switch (priority) {
+        case FTI_EROR:
+            fprintf(stream, "[ " FTI_COLOR_RED
+              "FTI Error - %06d" FTI_COLOR_RESET " ] : %s : %s \n",
+              FTI_Topo.myRank, msg, strerror(errno));
+            break;
+        case FTI_WARN:
+            fprintf(stream, "[ " FTI_COLOR_ORG
+              "FTI Warning %06d" FTI_COLOR_RESET " ] : %s \n",
+              FTI_Topo.myRank, msg);
+            break;
+        case FTI_INFO:
+            if (FTI_Topo.splitRank == 0) {
+                fprintf(stream, "[ " FTI_COLOR_GRN
+                  "FTI  Information" FTI_COLOR_RESET " ] : %s \n", msg);
             }
-        }
+            break;
+        case FTI_IDCP:
+            if (FTI_Topo.splitRank == 0) {
+                fprintf(stdout, "[ " FTI_COLOR_BLU
+                  "FTI  dCP Message" FTI_COLOR_RESET " ] : %s \n", msg);
+            }
+            break;
+        case FTI_DBUG:
+            fprintf(stream, "[FTI Debug - %06d] : %s \n",
+              FTI_Topo.myRank, msg);
+            break;
     }
     fflush(stdout);
 }

--- a/src/api.c
+++ b/src/api.c
@@ -248,11 +248,12 @@ int FTI_Status() {
 
 **/
 /*-------------------------------------------------------------------------*/
-fti_id_t FTI_InitType(int size) {
+fti_id_t FTI_InitType(size_t size) {
     FTIT_type *type;
     fti_id_t new_id = FTI_Exec.datatypes.ntypes;
+
     // Sanity Check
-    if (size < 1) {
+    if (!size) {
         FTI_Print("Types must have positive size", FTI_WARN);
         return FTI_NSCS;
     }
@@ -308,7 +309,7 @@ FTIT_type* FTI_GetType(fti_id_t id) {
 
 **/
 /*-------------------------------------------------------------------------*/
-fti_id_t FTI_InitComplexType(char* name, int size, FTIT_H5Group* h5group) {
+fti_id_t FTI_InitComplexType(char* name, size_t size, FTIT_H5Group* h5group) {
     FTIT_type *type;
     FTIT_complexType *structure;
     int type_id;

--- a/src/api.c
+++ b/src/api.c
@@ -238,8 +238,8 @@ int FTI_Status() {
 /*-------------------------------------------------------------------------*/
 /**
   @brief      Registers a new data type in FTI runtime
-  @param      size             The size of the data type.
-  @return     fti_id_t         An external handle to represent the new type.
+  @param      size             The data type size in bytes.
+  @return     fti_id_t         A handle to represent the new type.
 
   This function initalizes a data type.
   The type is treated as a black box for FTI.
@@ -301,7 +301,7 @@ FTIT_type* FTI_GetType(fti_id_t id) {
   @param      name            An optional type name
   @param      size            The total size of the complex data type
   @param      h5group         An optional H5 group identifier
-  @return     fti_id_t        An external handle to represent the new type.
+  @return     fti_id_t        A handle to represent the new type.
 
   Creates a complex data type that serves as a container for other data types.
   The components can be added using FTI_AddSimpleField and FTI_AddComplexField.
@@ -332,7 +332,7 @@ fti_id_t FTI_InitComplexType(char* name, int size, FTIT_H5Group* h5group) {
 /**
   @brief      Adds a simple type as a complex data type component.
   @param      id              The complex data type handle
-  @param      name            The field name
+  @param      name            An optional field name
   @param      fid             The field data type handle
   @param      offset          Offset of the field (use offsetof)
   @return     integer         FTI_SCES when successful, FTI_NSCS otherwise

--- a/src/conf.c
+++ b/src/conf.c
@@ -240,7 +240,6 @@ int FTI_ReadConf(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
 
     // Reading/setting execution metadata
     FTI_Exec->nbVar = 0;
-    FTI_Exec->nbType = 0;
     FTI_Exec->minuteCnt = 0;
     FTI_Exec->ckptCnt = 1;
     FTI_Exec->ckptIcnt = 0;

--- a/src/fortran/ftif.c
+++ b/src/fortran/ftif.c
@@ -62,18 +62,20 @@ int FTI_Init_fort_wrapper(char* configFile, int* globalComm) {
 }
 
 /**
- *   @brief      Initialize a FTIT_Type structure for a Fortran primitive type
- *   @param      type            The data type to be intialized
- *   @param      name            Fortran typename string
- *   @param      size            Type size in bytes
- *   @return     integer         FTI_SCES if successful
+ *   @brief      Registers a Fortran primitive in FTI type system
+ *   @param      name            Fortran data type mnemonic string
+ *   @param      size            The data type size in bytes
+ *   @return     fti_id_t        A handle for the new data type
  *
  *   This method first try to associate the Fortran primitive type to a C type.
- *   It does so by parsing the name and then the size of the data type.
+ *   It does so by parsing the type mnemonic and then its size.
+ *   Integers and logicals are mapped to integers of size 1, 2, 4 and 8.
+ *   Reals are mapped to float, real and long real.
+ *   Character is mapped to char regardless of size (byte array).
  *   If there is no direct correlation between C an Fortran, create a new type.
  *
  *   WARNING: We assume that C and Fortran types share the same binary format.
- *   For instance, the C float is usually defined by the IEEE 754 format.
+ *   For instance, the C float is defined by the IEEE 754 format.
  *   We would assume that Fortran real(4) types are also encoded as IEEE 754.
  *   This is usually the case but might be an error source on some compilers.
  **/
@@ -157,16 +159,14 @@ int FTI_SetAttribute_long_array_wrapper(int id, int ndims,
 }
 
 /**
- *   @brief      Initializes a complex hdf5 data type.
+ *   @brief      Initializes an hdf5-like empty complex data type.
  *   @param      size            Size of the structure.
  *   @param      name            Name of the structure.
- *   @return     integer         FTI_SCES if successful.
+ *   @return     integer         FTI_SCES if successful, FTI_NSCS otherwise.
  *
- *   This function initalizes a complex data type. the information needed is passed
- *   in typeDefinition, the rest is black box for FTI.
+ *   The components are added with FTI_AddSimpleField and FTI_AddComplexField.
  *
  **/
 fti_id_t FTI_InitComplexType_wrapper(char* name, int size) {
-  // TODO(alex): documentation
   return FTI_InitComplexType(name, size, NULL);
 }

--- a/src/fortran/ftif.c
+++ b/src/fortran/ftif.c
@@ -79,7 +79,7 @@ int FTI_Init_fort_wrapper(char* configFile, int* globalComm) {
  *   We would assume that Fortran real(4) types are also encoded as IEEE 754.
  *   This is usually the case but might be an error source on some compilers.
  **/
-fti_id_t FTI_InitPrimitiveType_C(const char *name, int size) {
+fti_id_t FTI_InitPrimitiveType_C(const char *name, size_t size) {
     int typecode = TYPECODE_NONE;
     char *dest;
     int i = 0;
@@ -167,6 +167,6 @@ int FTI_SetAttribute_long_array_wrapper(int id, int ndims,
  *   The components are added with FTI_AddSimpleField and FTI_AddComplexField.
  *
  **/
-fti_id_t FTI_InitComplexType_wrapper(char* name, int size) {
+fti_id_t FTI_InitComplexType_wrapper(char* name, size_t size) {
   return FTI_InitComplexType(name, size, NULL);
 }

--- a/src/fortran/ftif.c
+++ b/src/fortran/ftif.c
@@ -40,8 +40,6 @@
 #include <ctype.h>
 #include <stdio.h>
 
-#include "fti.h"
-#include "../interface.h"
 #include "ftif.h"
 
 #define TYPECODE_NONE 0
@@ -64,21 +62,6 @@ int FTI_Init_fort_wrapper(char* configFile, int* globalComm) {
 }
 
 /**
- *   @brief      Initializes a data type.
- *   @param      type            The data type to be intialized.
- *   @param      size            The size of the data type to be intialized.
- *   @return     integer         FTI_SCES if successful.
- *
- *   This function initalizes a data type. the only information needed is the
- *   size of the data type, the rest is black box for FTI.
- *
- **/
-int FTI_InitType_wrapper(FTIT_type** type, int size) {
-    *type = talloc(FTIT_type, 1);
-    return FTI_InitType(*type, size);
-}
-
-/**
  *   @brief      Initialize a FTIT_Type structure for a Fortran primitive type
  *   @param      type            The data type to be intialized
  *   @param      name            Fortran typename string
@@ -94,7 +77,7 @@ int FTI_InitType_wrapper(FTIT_type** type, int size) {
  *   We would assume that Fortran real(4) types are also encoded as IEEE 754.
  *   This is usually the case but might be an error source on some compilers.
  **/
-int FTI_InitPrimitiveType_C(FTIT_type** type, const char *name, int size) {
+fti_id_t FTI_InitPrimitiveType_C(const char *name, int size) {
     int typecode = TYPECODE_NONE;
     char *dest;
     int i = 0;
@@ -119,62 +102,35 @@ int FTI_InitPrimitiveType_C(FTIT_type** type, const char *name, int size) {
     case TYPECODE_INT:
       switch (size) {
       case sizeof(char):
-        *type = &FTI_CHAR;
-        break;
+        return FTI_CHAR;
       case sizeof(short):
-        *type = &FTI_SHRT;
-        break;
+        return FTI_SHRT;
       case sizeof(int):
-        *type = &FTI_INTG;
-        break;
+        return FTI_INTG;
       case sizeof(long):
-        *type = &FTI_LONG;
-        break;
+        return FTI_LONG;
       default:
-        return FTI_InitType_wrapper(type, size);
+        return FTI_InitType(size);
       }
       break;
     case TYPECODE_FLOAT:
       switch (size) {
       case sizeof(float):
-        *type = &FTI_SFLT;
-        break;
+        return FTI_SFLT;
       case sizeof(double):
-        *type = &FTI_DBLE;
-        break;
+        return FTI_DBLE;
       case sizeof(long double):
-        *type = &FTI_LDBE;
-        break;
+        return FTI_LDBE;
       default:
-        return FTI_InitType_wrapper(type, size);
+        return FTI_InitType(size);
       }
       break;
       case TYPECODE_CHAR:
-        *type = &FTI_CHAR;
-        break;
+        return FTI_CHAR;
       default:
-        return FTI_InitType_wrapper(type, size);
+        return FTI_InitType(size);
     }
     return FTI_SCES;
-}
-
-/**
- @brief      Stores or updates a pointer to a variable that needs to be protected.
- @param      id              ID for searches and update.
- @param      ptr             Pointer to the data structure.
- @param      count           Number of elements in the data structure.
- @param      type            Type of elements in the data structure.
- @return     integer         FTI_SCES if successful.
-
- This function stores a pointer to a data structure, its size, its ID,
- its number of elements and the type of the elements. This list of
- structures is the data that will be stored during a checkpoint and
- loaded during a recovery.
-
- **/
-/*-------------------------------------------------------------------------*/
-int FTI_Protect_wrapper(int id, void* ptr, int32_t count, FTIT_type* type) {
-    return FTI_Protect(id, ptr, count, *type);
 }
 
 int FTI_SetAttribute_string_wrapper(int id, char* attribute, int flag) {
@@ -202,9 +158,6 @@ int FTI_SetAttribute_long_array_wrapper(int id, int ndims,
 
 /**
  *   @brief      Initializes a complex hdf5 data type.
- *   @param      newType         The data type to be intialized.
- *   @param      typeDefinition  The definition of the data type to be intialized.
- *   @param      length          Number of fields in structure.
  *   @param      size            Size of the structure.
  *   @param      name            Name of the structure.
  *   @return     integer         FTI_SCES if successful.
@@ -213,10 +166,7 @@ int FTI_SetAttribute_long_array_wrapper(int id, int ndims,
  *   in typeDefinition, the rest is black box for FTI.
  *
  **/
-int FTI_InitComplexType_wrapper(FTIT_type** newType,
- FTIT_complexType* typeDefinition, int length, size_t size, char* name,
- FTIT_H5Group* h5group) {
-    *newType = talloc(FTIT_type, 1);
-    return FTI_InitComplexType(*newType, typeDefinition,
-            length, size, name, h5group);
+fti_id_t FTI_InitComplexType_wrapper(char* name, int size) {
+  // TODO(alex): documentation
+  return FTI_InitComplexType(name, size, NULL);
 }

--- a/src/fortran/ftif.h
+++ b/src/fortran/ftif.h
@@ -43,7 +43,7 @@
 #include "../interface.h"
 
 int FTI_Init_fort_wrapper(char* configFile, int* globalComm);
-fti_id_t FTI_InitPrimitiveType_C(const char *name, int size);
-fti_id_t FTI_InitComplexType_wrapper(char* name, int size);
+fti_id_t FTI_InitPrimitiveType_C(const char *name, size_t size);
+fti_id_t FTI_InitComplexType_wrapper(char* name, size_t size);
 
 #endif

--- a/src/fortran/ftif.h
+++ b/src/fortran/ftif.h
@@ -40,12 +40,10 @@
 #ifndef _FTIF_H
 #define _FTIF_H
 
+#include "../interface.h"
+
 int FTI_Init_fort_wrapper(char* configFile, int* globalComm);
-int FTI_InitType_wrapper(FTIT_type** type, int size);
-int FTI_Protect_wrapper(int id, void* ptr, int32_t count, FTIT_type* type);
-int FTI_InitPrimitiveType_C(FTIT_type** type, const char *name, int size);
-int FTI_InitComplexType_wrapper(FTIT_type** newType,
-  FTIT_complexType* typeDefinition, int length, size_t size,
-  char* name, FTIT_H5Group* parent);
+fti_id_t FTI_InitPrimitiveType_C(const char *name, int size);
+fti_id_t FTI_InitComplexType_wrapper(char* name, int size);
 
 #endif

--- a/src/fortran/ftif.h
+++ b/src/fortran/ftif.h
@@ -37,13 +37,25 @@
  *  @brief  Header file for the FTI Fortran interface.
  */
 
-#ifndef _FTIF_H
-#define _FTIF_H
+#ifndef SRC_FORTRAN_FTIF_H_
+#define SRC_FORTRAN_FTIF_H_
 
 #include "../interface.h"
+
+typedef struct FTI_FComplex4 {
+    float r, i;
+} FTI_FComplex4;
+
+typedef struct FTI_FComplex8 {
+    double r, i;
+} FTI_FComplex8;
+
+typedef struct FTI_FComplex16 {
+    long double r, i;
+} FTI_FComplex16;
 
 int FTI_Init_fort_wrapper(char* configFile, int* globalComm);
 fti_id_t FTI_InitPrimitiveType_C(const char *name, size_t size);
 fti_id_t FTI_InitComplexType_wrapper(char* name, size_t size);
 
-#endif
+#endif  // SRC_FORTRAN_FTIF_H_

--- a/src/fortran/interface.F90.bpp
+++ b/src/fortran/interface.F90.bpp
@@ -20,14 +20,6 @@ module FTI
   private
 
 
-  type, public :: FTI_type
-
-    type(c_ptr), private :: raw_type
-
-  endtype FTI_type
-
-
-
   !> Token returned if a FTI function succeeds.
   integer, parameter :: FTI_SCES = 0
   !> Token returned if a FTI function fails.
@@ -37,7 +29,7 @@ module FTI
   integer, parameter :: FTI_ATTRIBUTE_DIM = 2
 
 !$SH for T in ${FORTTYPES}; do
-  type(FTI_type) :: $(fti_type ${T})
+  integer :: $(fti_type ${T})
 !$SH done
 
 
@@ -152,13 +144,12 @@ module FTI
 
   interface
 
-    function FTI_InitType_impl(type_F, size_F) &
-            bind(c, name='FTI_InitType_wrapper')
+    function FTI_InitType_impl(size_F) &
+            bind(c, name='FTI_InitType')
 
       use ISO_C_BINDING
 
       integer(c_int) :: FTI_InitType_impl
-      type(c_ptr), intent(OUT) :: type_F
       integer(c_int), value :: size_F
 
     endfunction FTI_InitType_impl
@@ -166,13 +157,12 @@ module FTI
   endinterface
 
   interface
-    function FTI_InitPrimitiveType_impl(type_F, name, size_F) &
+    function FTI_InitPrimitiveType_impl(name, size_F) &
             bind(c, name='FTI_InitPrimitiveType_C')
 
       use ISO_C_BINDING
 
       integer(c_int) :: FTI_InitPrimitiveType_impl
-      type(c_ptr), intent(OUT) :: type_F
       character(c_char), intent(IN) :: name(*)
       integer(c_int), value :: size_F
 
@@ -211,22 +201,21 @@ module FTI
 
   interface
 
-    function FTI_Protect_impl(id_F, ptr, count_F, type_F) &
-            bind(c, name='FTI_Protect_wrapper')
+    function FTI_Protect_impl(id_F, ptr, count_F, tid) &
+            bind(c, name='FTI_Protect')
 
       use ISO_C_BINDING
 
       integer(c_int) :: FTI_Protect_impl
-      integer(c_int), value :: id_F
-      type(c_ptr), value :: ptr
+
+      integer(c_int),  value :: id_F
+      type(c_ptr),     value :: ptr
       integer(c_long), value :: count_F
-      type(c_ptr), value :: type_F
+      integer(c_int),  value :: tid
 
     endfunction FTI_Protect_impl
 
   endinterface
-
-
 
   interface
 
@@ -364,17 +353,15 @@ module FTI
 
   interface
 
-    function FTI_InitComplexType_impl(type_F, def_F, length, size, name) &
+    function FTI_InitComplexType_impl(name, size) &
             bind(c, name='FTI_InitComplexType_wrapper')
 
       use ISO_C_BINDING
 
-      integer(c_int) :: FTI_InitComplexType_impl
-      type(c_ptr), intent(OUT) :: type_F
-      type(c_ptr), intent(IN) :: def_F
-      integer(c_int), intent(IN) :: length
-      integer(c_long), intent(IN) :: size
-      character(c_char), intent(IN) :: name(*)
+      integer(c_int)                :: FTI_InitComplexType_impl
+
+      integer(c_long),   INTENT(IN) :: size
+      character(c_char), INTENT(IN) :: name(*)
 
     endfunction FTI_InitComplexType_impl
 
@@ -382,15 +369,17 @@ module FTI
 
   interface
 
-    function FTI_AddSimpleField_impl(def_F, type_F, offset, id, name) &
+    function FTI_AddSimpleField_impl(complex_tid, name, field_tid, offset) &
             bind(c, name='FTI_AddSimpleField')
 
       use ISO_C_BINDING
-      type(c_ptr), intent(INOUT) :: def_F
-      type(c_ptr), intent(IN) :: type_F
-      integer(c_long), intent(IN) :: offset
-      integer(c_int), value :: id
-      character(c_char), intent(IN) :: name(*)
+
+      integer(c_int)                :: FTI_AddSimpleField_impl
+
+      integer(c_int),    INTENT(IN) :: complex_tid
+      character(c_char), INTENT(IN) :: name(*)
+      integer(c_int),    INTENT(IN) :: field_tid
+      integer(c_long),   INTENT(IN) :: offset
 
     endfunction FTI_AddSimpleField_impl
 
@@ -398,17 +387,19 @@ module FTI
 
   interface
 
-    function FTI_AddComplexField_impl(def_F, type_F, offset, rank, dimLength, id, name) &
+    function FTI_AddComplexField_impl(complex_tid, name, field_tid, offset, ndims, dimLength) &
             bind(c, name='FTI_AddComplexField')
 
       use ISO_C_BINDING
-      type(c_ptr), intent(INOUT) :: def_F
-      type(c_ptr), intent(IN) :: type_F
-      integer(c_long), intent(IN) :: offset
-      integer(c_int), value :: rank
-      integer(c_int), intent(IN) :: dimLength(*)
-      integer(c_int), value :: id
-      character(c_char), intent(IN) :: name(*)
+
+      integer(c_int)                :: FTI_AddComplexField_impl
+
+      integer(c_int),    INTENT(IN) :: complex_tid
+      character(c_char), INTENT(IN) :: name(*)
+      integer(c_int),    INTENT(IN) :: field_tid
+      integer(c_long),   INTENT(IN) :: offset
+      integer(c_int),    INTENT(IN) :: ndims
+      integer(c_int),    INTENT(IN) :: dimLength(*)
 
     endfunction FTI_AddComplexField_impl
 
@@ -437,11 +428,13 @@ contains
     integer :: ii, ll
     integer(c_int) :: global_comm_c
 
+    !! Convert from Fortran string to C string
     ll = len_trim(config_file)
     do ii = 1, ll
       config_file_c(ii) = config_file(ii:ii)
     enddo
     config_file_c(ll+1) = c_null_char
+
     global_comm_c = int(global_comm, c_int)
     err = int(FTI_Init_impl(config_file_c, global_comm_c))
     global_comm = int(global_comm_c)
@@ -450,10 +443,7 @@ contains
     endif
 
 !$SH for T in ${FORTTYPES}; do
-    err = FTI_InitPrimitiveType($(fti_type ${T}), "${T}", int($(fort_sizeof ${T})_C_int/8_c_int, C_int))
-    if (err /= FTI_SCES ) then
-      return
-    endif
+    $(fti_type ${T}) = FTI_InitPrimitiveType("${T}", int($(fort_sizeof ${T})_C_int/8_c_int, C_int))
 !$SH done
 
   endsubroutine FTI_Init
@@ -584,44 +574,37 @@ contains
   !>  This function initalizes a data type. the only information needed is the
   !!  size of the data type, the rest is black box for FTI.
   !!  \brief    It initializes a data type.
-  !!  \param    type_F  (IN)    The data type to be intialized.
   !!  \param    size_F  (IN)    The size of the data type to be intialized.
-  !!  \param    err     (OUT)   Token for error handling.
-  !!  \return   integer         FTI_SCES if successful.
-  subroutine FTI_InitType(type_F, size_F, err)
-
-    type(FTI_type), intent(OUT) :: type_F
+  !!  \return   integer         The identifier for the new type.
+  function FTI_InitType(size_F) result(ret)
     integer, intent(IN) :: size_F
-    integer, intent(OUT) :: err
+    integer             :: ret
 
-    err = int(FTI_InitType_impl(type_F%raw_type, int(size_F, c_int)))
-
-  endsubroutine FTI_InitType
+    ret = int(FTI_InitType_impl(int(size_F, c_int)))
+  endfunction FTI_InitType
 
   !>  Try to initialize an FTIT_Type from a Fortran primitive datatype.
   !!  This function tries to map a Fortran primitive with a C primitive.
   !!  If there is not a valid match, this will create a new custom datatype.
   !!  \brief    Initializes a primitive data type in FTI.
-  !!  \param    type_F  (OUT)   The data type to be intialized.
   !!  \param    name    (IN)    The Fortran data type mnemonic.
   !!  \param    size_F  (IN)    The size of the data type in bytes.
-  !!  \return   integer         FTI_SCES if successful.
-  function FTI_InitPrimitiveType(type_F, name, size_F) result(ret)
+  !!  \return   integer         The identifier for the new type
+  function FTI_InitPrimitiveType(name, size_F) result(ret)
 
-    type(FTI_type),   intent(OUT)   :: type_F
     character(len=*), intent(IN)    :: name
     integer,          intent(IN)    :: size_F
-    integer                         :: ret
-
+    integer                         :: ret, ii, ll
     character, target, dimension(1:len_trim(name)+1) :: name_c
-    integer :: ii, ll
+
+    !! Transform from Fortran string to C string
     ll = len_trim(name)
     do ii = 1, ll
       name_c(ii) = name(ii:ii)
     enddo
     name_c(ll+1) = c_null_char
 
-    ret = int(FTI_InitPrimitiveType_impl(type_F%raw_type, name_c, int(size_F, c_int)))
+    ret = int(FTI_InitPrimitiveType_impl(name_c, int(size_F, c_int)))
   endfunction FTI_InitPrimitiveType
 
   !>  This function returns size of variable of given ID that is saved in metadata.
@@ -677,16 +660,15 @@ contains
   !!  \param    type_F  (IN)    Type of elements in the data structure.
   !!  \param    err     (OUT)   Token for error handling.
   !!  \return   integer         FTI_SCES if successful.
-  subroutine FTI_Protect_Ptr(id_F, ptr, count_F, type_F, err)
+  subroutine FTI_Protect_Ptr(id_F, ptr, count_F, tid, err)
 
     integer, intent(IN) :: id_F
     type(c_ptr), value :: ptr
     integer, intent(IN) :: count_F
-    type(FTI_type), intent(IN) :: type_F
+    type(integer), intent(IN) :: tid
     integer, intent(OUT) :: err
 
-    err = int(FTI_Protect_impl(int(id_F, c_int), ptr, int(count_F, c_long), &
-            type_F%raw_type))
+    err = int(FTI_Protect_impl(int(id_F, c_int), ptr, int(count_F, c_long), tid))
 
   endsubroutine FTI_Protect_Ptr
 !$SH for T in ${FORTTYPES}; do
@@ -860,19 +842,28 @@ contains
   !!  \param    offset  (IN)    Offset of field in a structure.
   !!  \param    id      (IN)    Id of field in a structure.
   !!  \param    name    (IN)    data field name in hdf5 checkpoint file.
-  subroutine FTI_AddSimpleField(def_F, type_F, offset, id, name)
+  function FTI_AddSimpleField(complex_tid, name, field_tid, offset) result(ret)
 
-    type(FTI_type), intent(INOUT) :: def_F
-    type(FTI_type), intent(IN) :: type_F
-    integer, intent(IN) :: offset
-    integer, intent(IN) :: id
+    integer                     :: ret
+
+    integer,          intent(IN) :: complex_tid
     character(len=*), intent(IN) :: name
+    integer,          intent(IN) :: field_tid
+    integer,          intent(IN) :: offset
 
+    character, target, dimension(1:len_trim(name)+1) :: name_c
+    integer                                          :: ii, ll
 
-    err = int(FTI_AddSimpleField_impl(def_F%raw_type, type_F%raw_type, int(offset, c_long), &
-              int(id, c_int), name))
+    !! Convert from Fortran string to C string
+    ll = len_trim(name)
+    do ii = 1, ll
+      name_c(ii) = name(ii:ii)
+    enddo
+    name_c(ll+1) = c_null_char
 
-  endsubroutine FTI_AddSimpleField
+    ret = int(FTI_AddSimpleField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), int(offset, c_long)))
+
+  endfunction
 
   !>  This function adds a field to the complex datatype. Use offsetof macro to
   !!  set offset. First ID must be 0, next one must be +1. If name is NULL FTI
@@ -886,45 +877,58 @@ contains
   !!  \param    dimLength (IN)    Dimention length for each dimention.
   !!  \param    id        (IN)    Id of a field in a structure.
   !!  \param    name      (IN)    data field name in hdf5 checkpoint file.
-  subroutine FTI_AddComplexField(def_F, type_F, offset, rank, dimLength, id, name)
+  function FTI_AddComplexField(complex_tid, name, field_tid, offset, ndims, dim_length) result(ret)
 
-    type(FTI_type), intent(INOUT) :: def_F
-    type(FTI_type), intent(IN) :: type_F
-    integer, intent(IN) :: offset
-    integer, intent(IN) :: rank
-    integer, intent(IN) :: dimLength(*)
-    integer, intent(IN) :: id
+    integer                     :: ret
+
+    integer,          intent(IN) :: complex_tid
     character(len=*), intent(IN) :: name
+    integer,          intent(IN) :: field_tid
+    integer,          intent(IN) :: offset
+    integer,          intent(IN) :: ndims
+    integer,          intent(IN) :: dim_length(*)
 
+    character, target, dimension(1:len_trim(name)+1) :: name_c
+    integer                                          :: ii, ll
 
-    err = int(FTI_AddComplexField_impl(def_F%raw_type, type_F%raw_type, int(offset, c_long), &
-              int(rank, c_int), dimLength, int(id, c_int), name))
+    !! Convert from Fortran string to C string
+    ll = len_trim(name)
+    do ii = 1, ll
+      name_c(ii) = name(ii:ii)
+    enddo
+    name_c(ll+1) = c_null_char
 
-  endsubroutine FTI_AddComplexField
+    ret = int(FTI_AddComplexField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), int(offset, c_long), &
+        int(ndims, c_int), dim_length))
+
+  endfunction FTI_AddComplexField
 
 !>  This function initalizes a data type. the only information needed is the
 !!  size of the data type, the rest is black box for FTI.
 !!  \brief    It initializes a data type.
-!!  \param    type_F  (IN)    The data type to be intialized.
 !!  \param    def_F   (IN)    The definition of the data type to be intialized.
 !!  \param    length  (IN)    Number of fields in the data structure.
 !!  \param    size    (IN)    Size of the sturcture.
 !!  \param    name    (IN)    data field name in hdf5 checkpoint file.
 !!  \param    err     (OUT)   Token for error handling.
 !!  \return   integer         FTI_SCES if successful.
-subroutine FTI_InitComplexType(type_F, def_F, length, size, name, err)
+function FTI_InitComplexType(name, size) result(ret)
+  integer                                          :: ret
 
-  type(FTI_type), intent(OUT) :: type_F
-  type(FTI_type), intent(IN) :: def_F
-  integer, intent(IN) :: length
-  integer, intent(IN) :: size
-  character(len=*), intent(IN) :: name
-  integer, intent(OUT) :: err
+  character(len=*), intent(IN)                     :: name
+  integer, intent(IN)                              :: size
 
-  err = int(FTI_InitComplexType_impl(type_F%raw_type, def_F%raw_type, int(length, c_int), &
-            int(size, c_long), name))
+  integer                                          :: ii, ll
+  character, target, dimension(1:len_trim(name)+1) :: name_c
 
-endsubroutine FTI_InitComplexType
+  !! Convert from Fortran string to C string
+  ll = len_trim(name)
+  do ii = 1, ll
+    name_c(ii) = name(ii:ii)
+  enddo
+  name_c(ll+1) = c_null_char
+  ret = int(FTI_InitComplexType_impl(name, int(size, c_long)))
+endfunction FTI_InitComplexType
 
 endmodule FTI
  

--- a/src/fortran/interface.F90.bpp
+++ b/src/fortran/interface.F90.bpp
@@ -150,7 +150,7 @@ module FTI
       use ISO_C_BINDING
 
       integer(c_int) :: FTI_InitType_impl
-      integer(c_int), value :: size_F
+      integer(c_size_t), value :: size_F
 
     endfunction FTI_InitType_impl
 
@@ -164,7 +164,7 @@ module FTI
 
       integer(c_int) :: FTI_InitPrimitiveType_impl
       character(c_char), intent(IN) :: name(*)
-      integer(c_int), value :: size_F
+      integer(c_size_t), value :: size_F
 
     endfunction FTI_InitPrimitiveType_impl
 
@@ -360,7 +360,7 @@ module FTI
 
       integer(c_int)                :: FTI_InitComplexType_impl
 
-      integer(c_long),   INTENT(IN) :: size
+      integer(c_size_t),   INTENT(IN) :: size
       character(c_char), INTENT(IN) :: name(*)
 
     endfunction FTI_InitComplexType_impl
@@ -379,7 +379,7 @@ module FTI
       integer(c_int),    INTENT(IN) :: complex_tid
       character(c_char), INTENT(IN) :: name(*)
       integer(c_int),    INTENT(IN) :: field_tid
-      integer(c_long),   INTENT(IN) :: offset
+      integer(c_size_t),   INTENT(IN) :: offset
 
     endfunction FTI_AddSimpleField_impl
 
@@ -576,10 +576,10 @@ contains
   !!  \param    size_F  (IN)    The data type size in bytes.
   !!  \return   fti_id_t        A handle to represent the new type.
   function FTI_InitType(size_F) result(ret)
-    integer, intent(IN) :: size_F
+    integer(c_size_t), intent(IN) :: size_F
     integer             :: ret
 
-    ret = int(FTI_InitType_impl(int(size_F, c_int)))
+    ret = int(FTI_InitType_impl(size_F))
   endfunction FTI_InitType
 
   !>  This method first try to associate the Fortran primitive type to a C type.
@@ -612,7 +612,7 @@ contains
     enddo
     name_c(ll+1) = c_null_char
 
-    ret = int(FTI_InitPrimitiveType_impl(name_c, int(size_F, c_int)))
+    ret = int(FTI_InitPrimitiveType_impl(name_c, int(size_F, c_size_t)))
   endfunction FTI_InitPrimitiveType
 
   !>  This function returns size of variable of given ID that is saved in metadata.
@@ -856,10 +856,10 @@ contains
 
     integer                      :: ret
 
-    integer,          intent(IN) :: complex_tid
-    character(len=*), intent(IN) :: name
-    integer,          intent(IN) :: field_tid
-    integer,          intent(IN) :: offset
+    integer,           intent(IN) :: complex_tid
+    character(len=*),  intent(IN) :: name
+    integer,           intent(IN) :: field_tid
+    integer(c_size_t), intent(IN) :: offset
 
     character, target, dimension(1:len_trim(name)+1) :: name_c
     integer                                          :: ii, ll
@@ -871,7 +871,7 @@ contains
     enddo
     name_c(ll+1) = c_null_char
 
-    ret = int(FTI_AddSimpleField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), int(offset, c_long)))
+    ret = int(FTI_AddSimpleField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), offset))
 
   endfunction
 
@@ -892,12 +892,12 @@ contains
 
     integer                     :: ret
 
-    integer,          intent(IN) :: complex_tid
-    character(len=*), intent(IN) :: name
-    integer,          intent(IN) :: field_tid
-    integer,          intent(IN) :: offset
-    integer,          intent(IN) :: ndims
-    integer,          intent(IN) :: dim_length(*)
+    integer,           intent(IN) :: complex_tid
+    character(len=*),  intent(IN) :: name
+    integer,           intent(IN) :: field_tid
+    integer(c_size_t), intent(IN) :: offset
+    integer,           intent(IN) :: ndims
+    integer,           intent(IN) :: dim_length(*)
 
     character, target, dimension(1:len_trim(name)+1) :: name_c
     integer                                          :: ii, ll
@@ -909,7 +909,7 @@ contains
     enddo
     name_c(ll+1) = c_null_char
 
-    ret = int(FTI_AddComplexField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), int(offset, c_long), &
+    ret = int(FTI_AddComplexField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), offset, &
         int(ndims, c_int), dim_length))
 
   endfunction FTI_AddComplexField
@@ -925,7 +925,7 @@ function FTI_InitComplexType(name, size) result(ret)
   integer                                          :: ret
 
   character(len=*), intent(IN)                     :: name
-  integer, intent(IN)                              :: size
+  integer(c_size_t), intent(IN)                    :: size
 
   integer                                          :: ii, ll
   character, target, dimension(1:len_trim(name)+1) :: name_c
@@ -936,7 +936,7 @@ function FTI_InitComplexType(name, size) result(ret)
     name_c(ii) = name(ii:ii)
   enddo
   name_c(ll+1) = c_null_char
-  ret = int(FTI_InitComplexType_impl(name, int(size, c_long)))
+  ret = int(FTI_InitComplexType_impl(name, size))
 endfunction FTI_InitComplexType
 
 endmodule FTI

--- a/src/fortran/interface.F90.bpp
+++ b/src/fortran/interface.F90.bpp
@@ -360,7 +360,7 @@ module FTI
 
       integer(c_int)                :: FTI_InitComplexType_impl
 
-      integer(c_size_t),   INTENT(IN) :: size
+      integer(c_size_t), value      :: size
       character(c_char), INTENT(IN) :: name(*)
 
     endfunction FTI_InitComplexType_impl
@@ -376,10 +376,10 @@ module FTI
 
       integer(c_int)                :: FTI_AddSimpleField_impl
 
-      integer(c_int),    INTENT(IN) :: complex_tid
-      character(c_char), INTENT(IN) :: name(*)
-      integer(c_int),    INTENT(IN) :: field_tid
-      integer(c_size_t),   INTENT(IN) :: offset
+      integer(c_int),    value      :: complex_tid
+      character(c_char), intent(in) :: name(*)
+      integer(c_int),    value      :: field_tid
+      integer(c_size_t), value      :: offset
 
     endfunction FTI_AddSimpleField_impl
 
@@ -394,11 +394,11 @@ module FTI
 
       integer(c_int)                :: FTI_AddComplexField_impl
 
-      integer(c_int),    INTENT(IN) :: complex_tid
+      integer(c_int),    value      :: complex_tid
       character(c_char), INTENT(IN) :: name(*)
-      integer(c_int),    INTENT(IN) :: field_tid
-      integer(c_long),   INTENT(IN) :: offset
-      integer(c_int),    INTENT(IN) :: ndims
+      integer(c_int),    value      :: field_tid
+      integer(c_long),   value      :: offset
+      integer(c_int),    value      :: ndims
       integer(c_int),    INTENT(IN) :: dimLength(*)
 
     endfunction FTI_AddComplexField_impl
@@ -856,10 +856,10 @@ contains
 
     integer                      :: ret
 
-    integer,           intent(IN) :: complex_tid
+    integer,           value      :: complex_tid
     character(len=*),  intent(IN) :: name
-    integer,           intent(IN) :: field_tid
-    integer(c_size_t), intent(IN) :: offset
+    integer,           value      :: field_tid
+    integer(c_size_t),    value      :: offset
 
     character, target, dimension(1:len_trim(name)+1) :: name_c
     integer                                          :: ii, ll
@@ -870,7 +870,7 @@ contains
       name_c(ii) = name(ii:ii)
     enddo
     name_c(ll+1) = c_null_char
-
+    !print *, "Adding field ", name_c, " of type ", int(field_tid, c_int), " to complex ", int(complex_tid, c_int)
     ret = int(FTI_AddSimpleField_impl(int(complex_tid, c_int), name_c, int(field_tid, c_int), offset))
 
   endfunction
@@ -892,11 +892,11 @@ contains
 
     integer                     :: ret
 
-    integer,           intent(IN) :: complex_tid
+    integer,           value :: complex_tid
     character(len=*),  intent(IN) :: name
-    integer,           intent(IN) :: field_tid
-    integer(c_size_t), intent(IN) :: offset
-    integer,           intent(IN) :: ndims
+    integer,           value      :: field_tid
+    integer(c_size_t), value      :: offset
+    integer,           value      :: ndims
     integer,           intent(IN) :: dim_length(*)
 
     character, target, dimension(1:len_trim(name)+1) :: name_c
@@ -936,7 +936,7 @@ function FTI_InitComplexType(name, size) result(ret)
     name_c(ii) = name(ii:ii)
   enddo
   name_c(ll+1) = c_null_char
-  ret = int(FTI_InitComplexType_impl(name, size))
+  ret = int(FTI_InitComplexType_impl(name_c, size))
 endfunction FTI_InitComplexType
 
 endmodule FTI

--- a/src/fortran/interface.F90.bpp
+++ b/src/fortran/interface.F90.bpp
@@ -571,11 +571,10 @@ contains
   end subroutine FTI_getIDFromString
 
 
-  !>  This function initalizes a data type. the only information needed is the
-  !!  size of the data type, the rest is black box for FTI.
-  !!  \brief    It initializes a data type.
-  !!  \param    size_F  (IN)    The size of the data type to be intialized.
-  !!  \return   integer         The identifier for the new type.
+  !>  
+  !!  \brief    Registers a new data type in FTI runtime.
+  !!  \param    size_F  (IN)    The data type size in bytes.
+  !!  \return   fti_id_t        A handle to represent the new type.
   function FTI_InitType(size_F) result(ret)
     integer, intent(IN) :: size_F
     integer             :: ret
@@ -583,13 +582,22 @@ contains
     ret = int(FTI_InitType_impl(int(size_F, c_int)))
   endfunction FTI_InitType
 
-  !>  Try to initialize an FTIT_Type from a Fortran primitive datatype.
-  !!  This function tries to map a Fortran primitive with a C primitive.
-  !!  If there is not a valid match, this will create a new custom datatype.
-  !!  \brief    Initializes a primitive data type in FTI.
-  !!  \param    name    (IN)    The Fortran data type mnemonic.
-  !!  \param    size_F  (IN)    The size of the data type in bytes.
-  !!  \return   integer         The identifier for the new type
+  !>  This method first try to associate the Fortran primitive type to a C type.
+  !!  It does so by parsing the type mnemonic and then its size.
+  !!  Integers and logicals are mapped to integers of size 1, 2, 4 and 8.
+  !!  Reals are mapped to float, real and long real.
+  !!  Character is mapped to char regardless of size (byte array).
+  !!  If there is no direct correlation between C an Fortran, create a new type.
+  !!  
+  !!  WARNING: We assume that C and Fortran types share the same binary format.
+  !!  For instance, the C float is defined by the IEEE 754 format.
+  !!  We would assume that Fortran real(4) types are also encoded as IEEE 754.
+  !!  This is usually the case but might be an error source on some compilers.
+  !!
+  !!  \brief    Registers a Fortran primitive in FTI type system
+  !!  \param    name    (IN)    Fortran data type mnemonic string
+  !!  \param    size_F  (IN)    The data type size in bytes.
+  !!  \return   integer         A handle for the new data type
   function FTI_InitPrimitiveType(name, size_F) result(ret)
 
     character(len=*), intent(IN)    :: name
@@ -657,7 +665,7 @@ contains
   !!  \param    id_F    (IN)    ID for searches and update.
   !!  \param    ptr     (IN)    C-Pointer to the data structure.
   !!  \param    count_F (IN)    Number of elements in the data structure.
-  !!  \param    type_F  (IN)    Type of elements in the data structure.
+  !!  \param    tid     (IN)    Type handle for the protected data structure.
   !!  \param    err     (OUT)   Token for error handling.
   !!  \return   integer         FTI_SCES if successful.
   subroutine FTI_Protect_Ptr(id_F, ptr, count_F, tid, err)
@@ -833,18 +841,20 @@ contains
 
   endsubroutine FTI_Finalize
 
-  !>  This function adds a field to the complex datatype. Use offsetof macro to
-  !!  set offset. First ID must be 0, next one must be +1. If name is NULL FTI
-  !!  will set "T${id}" name. Sets rank and dimLength to 1.
-  !!  \brief    It adds a fileld to a complex data type definition.
-  !!  \param    def_F   (IN)    The definition of the data type to add field.
-  !!  \param    type_F  (IN)    The data type of the field to add.
-  !!  \param    offset  (IN)    Offset of field in a structure.
-  !!  \param    id      (IN)    Id of field in a structure.
-  !!  \param    name    (IN)    data field name in hdf5 checkpoint file.
+  !>  Adds a scalar field to a complex data type at a given offset.
+  !!  Note that FTI does not check for memory boundaries within the data type.
+  !!  Specifying a wrong offset leads to undefined behavior.
+  !!  This can be avoided using the offsetof() macro.
+  !!
+  !!  \brief    Adds a simple type as a complex data type component.
+  !!  \param    complex_tid (IN) The complex data type handle
+  !!  \param    name        (IN) An optional field name
+  !!  \param    field_tid   (IN) The field data type handle
+  !!  \param    offset      (IN) Offset of the field (use offsetof)
+  !!  \return   integer          FTI_SCES when successfull or FTI_NSCS
   function FTI_AddSimpleField(complex_tid, name, field_tid, offset) result(ret)
 
-    integer                     :: ret
+    integer                      :: ret
 
     integer,          intent(IN) :: complex_tid
     character(len=*), intent(IN) :: name
@@ -865,18 +875,19 @@ contains
 
   endfunction
 
-  !>  This function adds a field to the complex datatype. Use offsetof macro to
-  !!  set offset. First ID must be 0, next one must be +1. If name is NULL FTI
-  !!  will set "T${id}" name. Sets rank and dimLength to 1.
-  !!  \brief    It adds a fileld to a complex data type definition.
-  !!  \brief    It adds a fileld to a complex data type definition.
-  !!  \param    def_F     (IN)    The definition of the data type to add field.
-  !!  \param    type_F    (IN)    The data type of the field to add.
-  !!  \param    offset    (IN)    Offset of field in a structure.
-  !!  \param    rank      (IN)    Rank of the array.
-  !!  \param    dimLength (IN)    Dimention length for each dimention.
-  !!  \param    id        (IN)    Id of a field in a structure.
-  !!  \param    name      (IN)    data field name in hdf5 checkpoint file.
+  !>  Adds an N-dimensional array field to a complex data type at a given offset.
+  !!  Note that FTI does not check for memory boundaries within the data type.
+  !!  Specifying a wrong offset leads to undefined behavior.
+  !!  This can be avoided using the offsetof() macro.
+  !!
+  !!  \brief    Adds a complex field to a complex data type.
+  !!  \param    complex_tid (IN) The complex data type handle
+  !!  \param    name        (IN) The field name
+  !!  \param    field_tid   (IN) The field data type handle
+  !!  \param    offset      (IN) Offset of the field (use offsetof)
+  !!  \param    ndims       (IN) The number of dimensions for the field
+  !!  \param    dim_length  (IN) Array of lengths for each dimension
+  !!  \return   integer          FTI_SCES when successful, FTI_NSCS otherwise
   function FTI_AddComplexField(complex_tid, name, field_tid, offset, ndims, dim_length) result(ret)
 
     integer                     :: ret
@@ -903,15 +914,13 @@ contains
 
   endfunction FTI_AddComplexField
 
-!>  This function initalizes a data type. the only information needed is the
-!!  size of the data type, the rest is black box for FTI.
-!!  \brief    It initializes a data type.
-!!  \param    def_F   (IN)    The definition of the data type to be intialized.
-!!  \param    length  (IN)    Number of fields in the data structure.
-!!  \param    size    (IN)    Size of the sturcture.
-!!  \param    name    (IN)    data field name in hdf5 checkpoint file.
-!!  \param    err     (OUT)   Token for error handling.
-!!  \return   integer         FTI_SCES if successful.
+!>  Creates a complex data type that serves as a container for other data types.
+!!  The components can be added using FTI_AddSimpleField and FTI_AddComplexField.
+!!
+!!  \brief    Initializes an empty complex data type.
+!!  \param    name   (IN)    An optional type name
+!!  \param    size   (IN)    The total size of the complex data type
+!!  \return   integer        A handle to represent the new type
 function FTI_InitComplexType(name, size) result(ret)
   integer                                          :: ret
 

--- a/src/meta.c
+++ b/src/meta.c
@@ -987,9 +987,10 @@ int FTI_CreateMetadata(FTIT_configuration* FTI_Conf, FTIT_execution* FTI_Exec,
     if (FTI_Data->data(&data, FTI_Exec->nbVar) != FTI_SCES) return FTI_NSCS;
 
     for (i = 0; i < FTI_Exec->nbVar; i++) {
-        int typeID = data[i].type->id - FTI_Exec->basicTypesOffsetId;
+        int typeID = data[i].type->id - FTI_Exec->datatypes.primitive_offset;
         myVarIDs[i] = data[i].id;
-        myVarTypeIDs[i] = (typeID < FTI_Exec->basicTypesNum) ? typeID : -1;
+        myVarTypeIDs[i] = (typeID < FTI_Exec->datatypes.nprimitives) ?
+          typeID : -1;
         myVarTypeSizes[i] = data[i].type->size;
         myVarSizes[i] =  data[i].size;
         myVarIDs[i] =  data[i].id;

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -94,7 +94,12 @@ void cleanup(char* pattern, ...);
         }                                                     \
     } while (0)
 
-#define TRY_ALLOC(dest, dtype, count) dest = (dtype*) calloc(sizeof(dtype), count);\
-                                     if (dest == NULL)
+#define TRY_ALLOC(dest, dtype, count) dest = \
+    (dtype*) calloc(sizeof(dtype), count);\
+    if (dest == NULL)
+
+/** Stringfy static functions **/
+#define STR_(X) #X
+#define STR(X) STR_(X)
 
 #endif  // FTI_MACROS_H_

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -94,6 +94,7 @@ void cleanup(char* pattern, ...);
         }                                                     \
     } while (0)
 
-
+#define TRY_ALLOC(dest, dtype, count) dest = (dtype*) calloc(sizeof(dtype), count);\
+                                     if (dest == NULL)
 
 #endif  // FTI_MACROS_H_

--- a/src/util/tools.c
+++ b/src/util/tools.c
@@ -519,7 +519,7 @@ char* FTI_GetHashHexStr(unsigned char* hash, int digestWidth,
 void FTI_CopyStringOrDefault(char* dest, char* src, char* fmt, ...) {
     if (src && strlen(src)) {
         // If src points to a non-zero string
-        strncpy(dest, src, FTI_BUFS);
+        strncpy(dest, src, strlen(src));
     } else {
         // Else, use default format instead
         va_list args;
@@ -540,7 +540,7 @@ void FTI_CopyStringOrDefault(char* dest, char* src, char* fmt, ...) {
 **/
 /*-------------------------------------------------------------------------*/
 inline int FTI_IsTypeComplex(FTIT_type *t) {
-  return t && t->structure != NULL;
+  return t && t->structure;
 }
 
 /*-------------------------------------------------------------------------*/
@@ -556,6 +556,6 @@ inline int FTI_IsTypeComplex(FTIT_type *t) {
 inline FTIT_type* FTI_GetComplexType(fti_id_t handle) {
     FTIT_type* t = FTI_GetType(handle);
     if (!FTI_IsTypeComplex(t))
-        return NULL;  // Either an initialized type in memory or a simple type
+        return NULL;
     return t;
 }

--- a/src/util/tools.c
+++ b/src/util/tools.c
@@ -531,6 +531,20 @@ void FTI_CopyStringOrDefault(char* dest, char* src, char* fmt, ...) {
 
 /*-------------------------------------------------------------------------*/
 /**
+  @brief      Checks if an allocated FTIT_type is complex
+  @param      t              A pointer to the FTIT_type
+  @return     int            Non-zero if true, zero if false
+
+  A complex type contains a non-empty structure field.
+
+**/
+/*-------------------------------------------------------------------------*/
+inline int FTI_IsTypeComplex(FTIT_type *t) {
+  return t && t->structure != NULL;
+}
+
+/*-------------------------------------------------------------------------*/
+/**
   @brief      Obtains the FTIT_type associated to a given type handle
   @param      handle         The data type handle
   @return     FTIT_type      An external handle to represent the new type
@@ -540,9 +554,8 @@ void FTI_CopyStringOrDefault(char* dest, char* src, char* fmt, ...) {
 **/
 /*-------------------------------------------------------------------------*/
 inline FTIT_type* FTI_GetComplexType(fti_id_t handle) {
-    // TODO(alex): Place this in a better spot
     FTIT_type* t = FTI_GetType(handle);
-    if (t == NULL || t->structure == NULL)
+    if (!FTI_IsTypeComplex(t))
         return NULL;  // Either an initialized type in memory or a simple type
     return t;
 }

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -29,6 +29,9 @@ int FTI_RmDir(char path[FTI_BUFS], int flag);
 int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
         FTIT_checkpoint* FTI_Ckpt, int level);
 
+void FTI_CopyStringOrDefault(char* dest, char* src, char* fmt, ...);
+FTIT_type* FTI_GetComplexType(fti_id_t handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -30,6 +30,7 @@ int FTI_Clean(FTIT_configuration* FTI_Conf, FTIT_topology* FTI_Topo,
         FTIT_checkpoint* FTI_Ckpt, int level);
 
 void FTI_CopyStringOrDefault(char* dest, char* src, char* fmt, ...);
+int FTI_IsTypeComplex(FTIT_type *t);
 FTIT_type* FTI_GetComplexType(fti_id_t handle);
 
 #ifdef __cplusplus

--- a/testing/suites/core/ckptDiffSizes/diffSizes.c
+++ b/testing/suites/core/ckptDiffSizes/diffSizes.c
@@ -87,9 +87,9 @@ int do_work(int world_rank, int world_size, int checkpoint_level, int fail) {
     int size;
   } cIters;
   cIters its = {0, (world_rank + 1) * INIT_SIZE};
-  FTIT_type itersInfo;
+  fti_id_t itersInfo;
   // creating new FTI type
-  FTI_InitType(&itersInfo, sizeof(cIters));
+  itersInfo = FTI_InitType(sizeof(cIters));
 
   int res;
   int j;

--- a/testing/suites/core/keepL4Ckpt/test.c
+++ b/testing/suites/core/keepL4Ckpt/test.c
@@ -22,6 +22,8 @@
 
 #define N 1024
 
+unsigned int seed = 42;
+
 int main(int argc, char* argv[]) {
   MPI_Init(NULL, NULL);
   FTI_Init(argv[1], MPI_COMM_WORLD);
@@ -42,17 +44,15 @@ int main(int argc, char* argv[]) {
     MPI_Abort(MPI_COMM_WORLD, -1);
   }
 
-  uint32_t* buffer = (uint32_t*)malloc(N * sizeof(uint32_t));
+  uint32_t* buffer = talloc(uint32_t, N);
   int i = 0;
   srand(time(NULL));
   for (; i < N; ++i) {
-    uint32_t rval = rand();
+    uint32_t rval = rand_r(&seed);
     memcpy(&buffer[i], &rval, sizeof(uint32_t));
   }
 
-  FTIT_type FTI_UINT32_T;
-
-  FTI_InitType(&FTI_UINT32_T, sizeof(uint32_t));
+  fti_id_t FTI_UINT32_T = FTI_InitType(sizeof(uint32_t));
 
   int id_cnt = 1;
   FTI_Protect(0, buffer, N, FTI_UINT32_T);

--- a/testing/suites/features/differentialCkpt/diff_test.h
+++ b/testing/suites/features/differentialCkpt/diff_test.h
@@ -4,8 +4,8 @@
  *
  */
 
-#ifndef _DIFF_TEST_H_
-#define _DIFF_TEST_H_
+#ifndef TESTING_SUITES_FEATURES_DIFFERENTIALCKPT_DIFF_TEST_H_
+#define TESTING_SUITES_FEATURES_DIFFERENTIALCKPT_DIFF_TEST_H_
 
 #include <stdbool.h>
 #include <assert.h>
@@ -46,7 +46,7 @@
 } while (0)
 
 #define EXIT_STD_ERR(MSG, ...) do {                \
-    fprintf(stderr, "[ERROR-%d] " MSG " : %s\n", grank, ##__VA_ARGS__, strerror(errno));       \
+    fprintf(stderr, "[ERROR-%d] " MSG " : %s\n", grank, ##__VA_ARGS__, strerror(errno));\
     exit(EXIT_FAILURE);                            \
 } while (0)
 
@@ -89,8 +89,7 @@ extern int numHeads;
 extern int finalTag;
 extern int headRank;
 
-static FTIT_type FTI_UI;
-static FTIT_type FTI_XOR_INFO;
+static fti_id_t FTI_UI, FTI_XOR_INFO;
 static uint32_t pat;
 static double share_ratio;
 
@@ -148,4 +147,4 @@ bool valid(dcp_info_t * info);
 void protect_buffers(dcp_info_t *info);
 void checkpoint(dcp_info_t *info, int ID, int level);
 void deallocate_buffers(dcp_info_t * info);
-#endif
+#endif  // TESTING_SUITES_FEATURES_DIFFERENTIALCKPT_DIFF_TEST_H_

--- a/testing/suites/features/fortran/datatypes/CMakeLists.txt
+++ b/testing/suites/features/fortran/datatypes/CMakeLists.txt
@@ -1,5 +1,6 @@
 enable_testing()
 
 InstallFortTestApplication("ckpt_f_primitives.exe" "ckpt_primitives.f90")
+InstallFortTestApplication("complex.exe" "complex.f90")
 InstallTestApplication("ckpt_c_primitives.exe" "ckpt_primitives.c")
 DeclareITFSuite("datatypes.itf" ${test_labels_current} "datatypes")

--- a/testing/suites/features/fortran/datatypes/ckpt_primitives.c
+++ b/testing/suites/features/fortran/datatypes/ckpt_primitives.c
@@ -24,6 +24,18 @@
 #define R8_INIT 20 + i
 #define R16_INIT 30 + i
 
+typedef struct Complex4 {
+    float r, i;
+} Complex4;
+
+typedef struct Complex8 {
+    double r, i;
+} Complex8;
+
+typedef struct Complex16 {
+    long double r, i;
+} Complex16;
+
 int main(int argc, char * argv[]) {
   char *configfile;
   int doInitData, rank, ret, i;
@@ -43,6 +55,12 @@ int main(int argc, char * argv[]) {
   float r4[SIZE];
   double r8[SIZE];
   long double r16[SIZE];
+
+  Complex4 cp4[SIZE];
+  Complex8 cp8[SIZE];
+  Complex16 cp16[SIZE];
+
+  fti_id_t complex_4, complex_8, complex_16;
 
   if (argc < 2) {
     printf("Expected two arguments: configfile (str) and doInitData (bool)");
@@ -77,8 +95,24 @@ int main(int argc, char * argv[]) {
       r4[i] = R4_INIT;
       r8[i] = R8_INIT;
       r16[i] = R16_INIT;
+      cp4[i].i = i;
+      cp4[i].r = i;
+      cp8[i].i = i;
+      cp8[i].r = i;
+      cp16[i].i = i;
+      cp16[i].r = i;
     }
   }
+  // Initializing custom types
+  complex_4 = FTI_InitComplexType("Complex4", sizeof(Complex4), NULL);
+  FTI_AddSimpleField(complex_4, "r", FTI_SFLT, offsetof(Complex4, r));
+  FTI_AddSimpleField(complex_4, "i", FTI_SFLT, offsetof(Complex4, i));
+  complex_8 = FTI_InitComplexType("Complex8", sizeof(Complex8), NULL);
+  FTI_AddSimpleField(complex_8, "r", FTI_SFLT, offsetof(Complex8, r));
+  FTI_AddSimpleField(complex_8, "i", FTI_SFLT, offsetof(Complex8, i));
+  complex_16 = FTI_InitComplexType("Complex16", sizeof(Complex16), NULL);
+  FTI_AddSimpleField(complex_16, "r", FTI_SFLT, offsetof(Complex16, r));
+  FTI_AddSimpleField(complex_16, "i", FTI_SFLT, offsetof(Complex16, i));
 
   FTI_Protect(0, c1, SIZE, FTI_CHAR);
 
@@ -95,6 +129,10 @@ int main(int argc, char * argv[]) {
   FTI_Protect(30, r4, SIZE, FTI_SFLT);
   FTI_Protect(31, r8, SIZE, FTI_DBLE);
   FTI_Protect(32, r16, SIZE, FTI_LDBE);
+
+  FTI_Protect(40, cp4, SIZE, complex_4);
+  FTI_Protect(41, cp8, SIZE, complex_8);
+  FTI_Protect(42, cp16, SIZE, complex_16);
 
   /**
    * If the application initialized the data, do the following:
@@ -177,6 +215,21 @@ int main(int argc, char * argv[]) {
     if (r16[i] != R16_INIT) {
       if (rank == 0)
         printf("real(16) was corrupted %Lf\n", r16[i]);
+      goto end;
+    }
+    if (cp4[i].i != i || cp4[i].r != i) {
+      if (rank == 0)
+        printf("complex(4) was corrupted %f\n", cp4[i]);
+      goto end;
+    }
+    if (cp8[i].i != i || cp8[i].r != i) {
+      if (rank == 0)
+        printf("complex(8) was corrupted %f\n", cp8[i]);
+      goto end;
+    }
+    if (cp16[i].i != i || cp16[i].r != i) {
+      if (rank == 0)
+        printf("complex(16) was corrupted %Lf\n", cp16[i]);
       goto end;
     }
   }

--- a/testing/suites/features/fortran/datatypes/ckpt_primitives.f90
+++ b/testing/suites/features/fortran/datatypes/ckpt_primitives.f90
@@ -1,4 +1,7 @@
-!> @author Alexandre de Limas Santana
+!> Copyright (c) 2017 Leonardo A. Bautista-Gomez
+!> All rights reserved
+!>
+!> @author Alexandre de Limas Santana (alexandre.delimassantana@bsc.es)
 !> @date   August, 2020
 !> @brief  Checkpoint primitive types and validate FTI meta-data
 

--- a/testing/suites/features/fortran/datatypes/ckpt_primitives.f90
+++ b/testing/suites/features/fortran/datatypes/ckpt_primitives.f90
@@ -34,6 +34,10 @@ program checkpoint_primitives
    real(8), pointer      :: r8(:)
    real(16), pointer     :: r16(:)
 
+   complex(4), pointer   :: cp4(:)
+   complex(8), pointer   :: cp8(:)
+   complex(16), pointer  :: cp16(:)
+
    ! Parse program arguments before starting
    if (command_argument_count() .NE. 2) THEN
       write (*, *) 'Expected two arguments: configfile (str), doInitData (int)'
@@ -60,6 +64,10 @@ program checkpoint_primitives
    allocate (r4(SIZE))
    allocate (r8(SIZE))
    allocate (r16(SIZE))
+
+   allocate (cp4(SIZE))
+   allocate (cp8(SIZE))
+   allocate (cp16(SIZE))
 
    call MPI_Init(err)
    FTI_comm_world = MPI_COMM_WORLD
@@ -90,6 +98,10 @@ program checkpoint_primitives
          r4(i) = 10 + (i-1)
          r8(i) = 20 + (i-1)
          r16(i) = 30 + (i-1)
+
+         cp4(i) = CMPLX(i-1, i-1)
+         cp8(i) = CMPLX(i-1, i-1)
+         cp16(i) = CMPLX(i-1, i-1)
       end do
    else if (rank == 0) then
       print *, "Application initializes its data with using checkpoints"
@@ -110,6 +122,10 @@ program checkpoint_primitives
    call FTI_Protect(30, r4, err)
    call FTI_Protect(31, r8, err)
    call FTI_Protect(32, r16, err)
+
+   call FTI_Protect(40, cp4, err)
+   call FTI_Protect(41, cp8, err)
+   call FTI_Protect(42, cp16, err)
 
    ! If the application initialized the data:
    ! 1) Checkpoint the data
@@ -200,6 +216,24 @@ program checkpoint_primitives
       if (r16(i) /= 30 + (i - 1)) then
          if (rank == 0) then
             print *, "real(16) was corrupted: ", r16(i)
+         end if
+         call exit(1)
+      end if
+      if (cp4(i) /= CMPLX(i-1, i-1)) then
+         if (rank == 0) then
+            print *, "complex(4) was corrupted: ", cp4(i)
+         end if
+         call exit(1)
+      end if
+      if (cp8(i) /= CMPLX(i-1, i-1)) then
+         if (rank == 0) then
+            print *, "complex(8) was corrupted: ", cp8(i)
+         end if
+         call exit(1)
+      end if
+      if (cp16(i) /= CMPLX(i-1, i-1)) then
+         if (rank == 0) then
+            print *, "complex(16) was corrupted: ", cp16(i)
          end if
          call exit(1)
       end if

--- a/testing/suites/features/fortran/datatypes/complex.f90
+++ b/testing/suites/features/fortran/datatypes/complex.f90
@@ -1,0 +1,208 @@
+!> Copyright (c) 2017 Leonardo A. Bautista-Gomez
+!> All rights reserved
+!>
+!> @author Alexandre de Limas Santana (alexandre.delimassantana@bsc.es)
+!> @date   September, 2020
+!> @brief  Checkpoint complex types and validate FTI meta-data
+!>
+!> @details
+!> This program tests the use of the following functions in Fortran:
+!> - FTI_InitType;
+!> - FTI_InitComplexType;
+!> - FTI_AddSimpleField;
+!> - FTI_AddComplexField;
+!> - FTI_Protect (with user-defined data types).
+!>
+!> We define structures that compose different use cases for these functions.
+!> - Foo has only simple types;
+!> - Bar encapsulates a Foo structure;
+!> - BarVec encapsulates an array of Foo structures.
+!>
+!> The program consists of array and scalar initializations for these types.
+!> In the first execution, the doInitData must be true.
+!> The values are initialized and checkpointed in the first execution.
+!> In the second execution, doInitData must be false.
+!> The values are recovered and checked in the second execution.
+!>
+!> This program can be a nice tool to validate/visualize FTI/HDF5 integration.
+!> To do this, run with doInitData and use h5dump on the checkpoint files.
+
+program checkpoint_complex
+    use ISO_C_BINDING
+    use FTI
+#ifndef MPI_USE_HEADER
+    use MPI
+#else
+    include 'mpif.h'
+#endif
+
+    type :: foo
+        integer(4) :: A
+        real(4)    :: B
+    end type
+
+    type :: bar
+        type(foo)               :: foos
+        integer(2)              :: x
+    end type
+
+    type :: barvec
+        type(foo), dimension(2) :: foos
+        integer(2)              :: x
+    end type
+
+    ! Application Parameters
+    character*255           :: configfile
+    integer                 :: doInitData, corrupted
+    integer, parameter      :: SIZE = 3
+    ! FTI data
+    integer                 :: foo_tid, foo_complex_tid, bar_tid, barvec_tid
+    integer, target         :: ierr, rank, FTI_COMM_WORLD
+    ! Application data
+    type(foo), target                       :: single
+    type(foo), dimension(SIZE), target      :: vec
+    type(foo), dimension(SIZE,SIZE), target :: matrix
+    type(foo), target                       :: single_described
+    type(bar), target                       :: container
+    type(barvec), target                    :: cont_vec
+    integer, dimension(1), target           :: list
+
+    ! Parse program arguments before starting
+    if (command_argument_count() .NE. 2) THEN
+        write (*, *) 'Expected two arguments: configfile (str), doInitData (int)'
+        stop
+    endif
+    call get_command_argument(2, configfile)
+    read (configfile, *) doInitData
+    call get_command_argument(1, configfile)
+
+    ! Start program
+    call MPI_Init(ierr)
+    FTI_comm_world = MPI_COMM_WORLD
+    call FTI_Init(configfile, FTI_comm_world, ierr)
+    call MPI_Comm_rank(FTI_comm_world, rank, ierr)
+    corrupted = 0
+
+    ! Declare simple and complex user types
+    foo_tid = FTI_InitType(sizeof(single))
+    foo_complex_tid = FTI_InitComplexType("foo", sizeof(single_described))
+    bar_tid = FTI_InitComplexType("bar", sizeof(container))
+    barvec_tid = FTI_InitComplexType("barvec", sizeof(cont_vec))
+
+    ! Populate complex type definitions for FOO
+    ierr = FTI_AddSimpleField(foo_complex_tid, "A", FTI_INTEGER4, int(0,c_size_t))
+    if(ierr == FTI_NSCS) then
+        call exit(1)
+    end if
+    ierr = FTI_AddSimpleField(foo_complex_tid, "B", FTI_REAL4, sizeof(single%A))
+    if(ierr == FTI_NSCS) then
+        call exit(1)
+    end if
+    ! Populate complex type definitions for BAR
+    ierr = FTI_AddSimpleField(bar_tid, "foos", foo_complex_tid, int(0,c_size_t))
+    if(ierr == FTI_NSCS) then
+        call exit(1)
+    end if
+    ierr = FTI_AddSimpleField(bar_tid, "x", FTI_INTEGER2, sizeof(container%foos))
+    if(ierr == FTI_NSCS) then
+        call exit(1)
+    end if
+    ! Populate complex type definitions for BARVEC
+    list = 2
+    ierr = FTI_AddComplexField(barvec_tid, "foos", foo_complex_tid, int(0,c_size_t), 1, list)
+    if(ierr == FTI_NSCS) then
+        call exit(1)
+    end if
+    ierr = FTI_AddSimpleField(barvec_tid, "x", FTI_INTEGER2, sizeof(cont_vec%foos))
+    if(ierr == FTI_NSCS) then
+        call exit(1)
+    end if
+
+    call FTI_Protect(1, c_loc(single), 1, foo_tid, ierr)
+    call FTI_Protect(2, c_loc(vec), SIZE, foo_tid, ierr)
+    call FTI_Protect(3, c_loc(matrix), SIZE*SIZE, foo_tid, ierr)
+    call FTI_Protect(4, c_loc(single_described), 1, foo_complex_tid, ierr)
+    call FTI_Protect(5, c_loc(container), 1, bar_tid, ierr)
+    call FTI_Protect(6, c_loc(cont_vec), 1, barvec_tid, ierr)
+
+    call FTI_Status(ierr)
+    if (doInitData .eq. 1) then
+        single%A = 1
+        single%B = 2.0
+        single_described%A = 100
+        single_described%B = 200.0
+        container%foos%A = 1000
+        container%foos%B = 1000 + 0.1
+        container%x = 99
+        cont_vec%foos(1)%A = 42
+        cont_vec%foos(1)%B = 24
+        cont_vec%foos(2)%A = 37
+        cont_vec%foos(2)%B = 73
+        cont_vec%x = 101
+        do i = 1, SIZE
+            vec(i)%A = i
+            vec(i)%B = i + 0.1
+            do j = 1, SIZE
+                matrix(i,j)%A = i + 10 * j
+                matrix(i,j)%B = i + 10 * j + 0.1
+            end do
+        end do
+        call FTI_Checkpoint(1, 1, ierr)
+        call MPI_Barrier(FTI_COMM_WORLD, ierr)
+        if(ierr == FTI_NSCS .and. rank == 0) then
+            print *, "Failed to create checkpoint"
+        end if
+    else
+        call FTI_Recover(ierr)
+        ! Check variable: single
+        if(rank == 0) then
+            if (single%A /= 1 .or. single%B /= 2.0) then
+                print *, "single was corrupted."
+            end if
+            print *, "single: ", single%A, ", ", single%B
+        
+            ! Check variable: single_described
+            if (single_described%A /= 100 .or. single_described%B /= 200.0) then
+                print *, "single described was corrupted."
+                corrupted = 1
+            end if
+            print *, "single_described: ", single_described%A, ", ", single_described%B 
+            ! Check variable: container
+            if (container%foos%A /= 1000 .or. container%foos%B /= 1000 + 0.1 .or. container%x /= 99) then
+                print *, "container was corrupted."
+                corrupted = 1
+            end if
+            print *, "container: ", container%foos%A, ", ", container%foos%B, ", ", container%x
+            ! Check variable: cont_vec
+            if (cont_vec%foos(1)%A /= 42 .or. cont_vec%foos(1)%B /= 24 .or. &
+                cont_vec%foos(2)%A /= 37 .or. cont_vec%foos(2)%B /= 73 .or. &
+                cont_vec%x /= 101) then
+                    print *, "foo vector container was corrupted."
+                    corrupted = 1
+            end if
+            print *, "foo vector container: "
+            print *, "First: ", cont_vec%foos(1)%A, ", ", cont_vec%foos(1)%B
+            print *, "Second: ", cont_vec%foos(2)%A, ", ", cont_vec%foos(2)%B
+            print *, "X: ", cont_vec%x
+            ! Check variable: vec
+            do i = 1, SIZE
+                if (vec(i)%A /= i .or. vec(i)%B /= i + 0.1) then
+                    print *, "vector was corrupted."
+                    corrupted = 1
+                end if
+                print *, "vector(", i, "): ", vec(i)%A, ", ", vec(i)%B 
+                ! Check variable matrix
+                do j = 1, SIZE
+                    if (matrix(i,j)%A /= i+10*j .or. matrix(i,j)%B /= i+10*j+0.1) then
+                        print *, "matrix was corrupted."
+                        corrupted = 1
+                    end if
+                    print *, "matrix(", i, ",", j, "): ", matrix(i,j)%A, ", ", matrix(i,j)%B 
+                end do
+            end do
+        end if
+        call FTI_Finalize(ierr)
+    end if
+    call MPI_Finalize(ierr)
+    call exit(corrupted)
+end program

--- a/testing/suites/features/fortran/datatypes/datatypes.itf
+++ b/testing/suites/features/fortran/datatypes/datatypes.itf
@@ -54,11 +54,34 @@ fortran_to_c_map() {
     # Both applications should be able to recover for all primitive data-types
     fti_run_success $c_app ${itf_cfg['fti:config']} 0
     fti_run_success $f90_app $config_copy 0
-    pass
+}
+
+fortran_complex() {
+  # Brief:
+  # Test the definition of complex types in Fortran ( FTI_InitComplexType API )
+  #
+  # Details:
+  # Two executions for creating and restoring to/from checkpoint files.
+  # The application uses the FTI API for complex data type handling.
+  # If the first application fails, there might be errors on the API calls.
+  # If the second application fails, the bindings to Fortran may have problems.
+  local app="$(dirname ${BASH_SOURCE[0]})/complex.exe"
+  local app_id_c app_id_f90 meta_dir
+
+  param_parse '+iolib' $@
+  fti_config_set 'ckpt_io' $iolib
+
+  fti_run_success $app ${itf_cfg['fti:config']} 1
+  fti_run_success $app ${itf_cfg['fti:config']} 0
+  pass
 }
 
 # -------------------------- ITF Register test cases --------------------------
 
 for iolib in $fti_io_ids; do
   itf_case 'fortran_to_c_map' "--iolib=$iolib"
+done
+
+for iolib in $fti_io_ids; do
+  itf_case 'fortran_complex' "--iolib=$iolib"
 done

--- a/testing/suites/features/hdf5/hdf5CreateBasePattern.c
+++ b/testing/suites/features/hdf5/hdf5CreateBasePattern.c
@@ -25,7 +25,7 @@
 
 typedef struct AsByteArray {
   char character;
-  int32_t longs[1024];
+  long longs[1024];
 } AsByteArray;
 
 typedef struct Chars {
@@ -35,15 +35,15 @@ typedef struct Chars {
 } Chars;
 
 typedef struct Integers {
-  int16_t shortInteger;
+  short shortInteger;
   int integer;
-  int32_t longInteger;
+  long longInteger;
 } Integers;
 
 typedef struct UIntegers {
-  uint16_t shortInteger;
+  unsigned short shortInteger;
   unsigned int integer;
-  uint32_t longInteger;
+  unsigned long longInteger;
 } UIntegers;
 
 typedef struct Floats {

--- a/testing/suites/features/hdf5/hdf5noFTI.c
+++ b/testing/suites/features/hdf5/hdf5noFTI.c
@@ -26,7 +26,7 @@
 
 typedef struct AsByteArray {
   char character;
-  int32_t longs[1024];
+  long longs[1024];
 } AsByteArray;
 
 typedef struct Chars {
@@ -36,15 +36,15 @@ typedef struct Chars {
 } Chars;
 
 typedef struct Integers {
-  int16_t shortInteger;
+  short shortInteger;
   int integer;
-  int32_t longInteger;
+  unsigned long longInteger;
 } Integers;
 
 typedef struct UIntegers {
-  uint16_t shortInteger;
+  unsigned short shortInteger;
   unsigned int integer;
-  uint32_t longInteger;
+  unsigned long longInteger;
 } UIntegers;
 
 typedef struct Floats {
@@ -98,7 +98,7 @@ int verifyChars(Chars* in, int shift, int rank, char* name) {
     }
     for (j = 0; j < 1024; j++) {
       if (in->bytes[i].longs[j] != (j + 1) * 2 + shift) {
-        printf("[ %06d ] : %s.bytes[%d].longs[%d] = %ld should be %d \n", rank,
+        printf("[ %06d ] : %s.bytes[%d].longs[%d] = %d should be %d \n", rank,
                name, i, j, in->bytes[i].longs[j], (j + 1) * 2 + shift);
         return VERIFY_FAILED;
       }
@@ -119,7 +119,7 @@ int verifyInts(Integers* in, int shift, int rank, char* name) {
     return VERIFY_FAILED;
   }
   if (in->longInteger != -1234 - shift) {
-    printf("[ %06d ] : %s.shortInteger = %ld should be %d \n", rank, name,
+    printf("[ %06d ] : %s.shortInteger = %d should be %d \n", rank, name,
            in->longInteger, -1234 - shift);
     return VERIFY_FAILED;
   }
@@ -142,7 +142,7 @@ int verifyUInts(UIntegers* in, int shift, int rank, char* name) {
     return VERIFY_FAILED;
   }
   if (in->longInteger != 1234 + shift) {
-    printf("[ %06d ] : %s.shortInteger = %lu should be %u \n", rank, name,
+    printf("[ %06d ] : %s.shortInteger = %u should be %u \n", rank, name,
            in->longInteger, 1234 + shift);
     return VERIFY_FAILED;
   }

--- a/testing/suites/features/variateProcessorRestart/test.c
+++ b/testing/suites/features/variateProcessorRestart/test.c
@@ -160,14 +160,12 @@ int main(int argc, char **argv) {
   };
 
   // create FTI type of structure
-  FTIT_complexType FTI_NEW_STRUCT_def;
-  FTI_AddSimpleField(&FTI_NEW_STRUCT_def, &FTI_INTG,
-                     offsetof(struct STRUCT, one), 0, "one");
-  FTI_AddSimpleField(&FTI_NEW_STRUCT_def, &FTI_INTG,
-                     offsetof(struct STRUCT, two), 1, "two");
-  FTIT_type FTI_NEW_STRUCT;
-  FTI_InitComplexType(&FTI_NEW_STRUCT, &FTI_NEW_STRUCT_def, 2,
-                      sizeof(struct STRUCT), "struct_one_two", NULL);
+  fti_id_t FTI_NEW_STRUCT =
+    FTI_InitComplexType("struct_one_two", sizeof(struct STRUCT), NULL);
+  FTI_AddSimpleField(FTI_NEW_STRUCT, "one", FTI_INTG,
+    offsetof(struct STRUCT, one));
+  FTI_AddSimpleField(FTI_NEW_STRUCT, "two", FTI_INTG,
+                     offsetof(struct STRUCT, two));
 
   // create a group
   FTIT_H5Group gr;


### PR DESCRIPTION
This patch cover issue 343, providing a re-work on the FTI data type handling subsystem.

The new version hides internal structures to represent data types from users (i.e. makes them opaque).
Data types are still registered with the former API calls: FTI_InitType and FTI_InitComplexType.
However, these functions return an **fti_id_t** (i.e integer) which serves as a representation for that type (i.e handle).
FTI users will now only use handles to inform the FTI engine of the types it must create/edit/checkpoint.
This patch breaks compatibility with FTI 1.4 on the following functions due to the use of handles:
- FTI_InitType
- FTI_InitComplexType
- FTI_AddSimpleField
- FTI_AddComplexField
- FTI_Protect
- FTI_DefineGlobalDataset
These functions are covered in the current FTI test suites, namely the HDF5 support feature.
Also, all tests, examples, and tutorials applications have been adjusted to function properly.

This patch adjusts the Fortran Interface to the aforementioned refactor.
This patch includes a mapping between the Fortran primitive "complex" type and a C struct of equivalent precision (e.g complex(8) is mapped to struct {double r, i}).
With this addition, all Fortran primitive types are pre-mapped to primitive C.
Therefore, there are no more duplicate entries for primitive data types in the FTI data type system.

The first set of Fortran tests is added in CI to assert the correct functioning of this patch features.
The suite covers the following aspects of FTI:
- Fortran compilation;
- Fortran primitive type representation in FTI (required for FTI_Protect);
- Fortran user-defined type representation in FTI (both complex and simple);
- Default FTI use case on Fortran ( FTI_Init, FTI_Protect, FTI_Checkpoint, FTI_Recover, FTI_Finalize).

The new test suite is classified with the **feature/fortran/datatype** hierarchical labels for CTest and ITF test runners.
The test is configured to execute on all merge scenarios (i.e develop and master).

This patch also covers issue 344, which was only a set of small typos in the CMake scripts.