### PR TITLE
removes compiler warnings

### DIFF
--- a/include/fti.h
+++ b/include/fti.h
@@ -106,7 +106,7 @@ extern "C" {
   void* FTI_Realloc(int id, void* ptr);
   int FTI_BitFlip(int datasetID);
   int FTI_Checkpoint(int id, int level);
-  int FTI_GetStageDir(const char* stageDir, int maxLen);
+  int FTI_GetStageDir(char* stageDir, int maxLen);
   int FTI_GetStageStatus(int ID);
   int FTI_SendFile(const char* lpath, const char *rpath);
   int FTI_Recover();

--- a/src/api.c
+++ b/src/api.c
@@ -480,7 +480,7 @@ int FTI_AddVectorField(fti_id_t id, const char* name,
   FTI_NSCS is returned.
  **/
 /*-------------------------------------------------------------------------*/
-int FTI_GetStageDir(const char* stageDir, int maxLen) {
+int FTI_GetStageDir(char* stageDir, int maxLen) {
     if (!FTI_Conf.stagingEnabled) {
         FTI_Print("'FTI_GetStageDir' -> Staging disabled,"
           " no action performed.", FTI_WARN);
@@ -3009,7 +3009,7 @@ int FTI_RecoverVar(int id) {
  **/
 /*-------------------------------------------------------------------------*/
 int FTI_RecoverVarFinalize() {
-    int res;
+    int res = FTI_SCES;
 
     if (FTI_Exec.ckptLvel == 4) {
         if (FTI_Ckpt[4].recoIsDcp && FTI_Conf.dcpPosix) {

--- a/src/stage.c
+++ b/src/stage.c
@@ -1067,7 +1067,7 @@ int FTI_GetRequestField(int ID, FTIT_RequestField val) {
 
     uint32_t field = idxRequest[ID];
 
-    int query;
+    int query = FTI_NSCS;
 
     switch (val) {
         case FTI_SIF_ALL:
@@ -1170,7 +1170,7 @@ int FTI_GetStatusField(FTIT_execution *FTI_Exec, FTIT_topology *FTI_Topo,
     MPI_Win_shared_query(stageWin, source, &size, &disp, &(status));
     uint8_t status_cpy = status[ID];
 
-    int query;
+    int query = FTI_NSCS;
 
     switch (val) {
         case FTI_SIF_VAL:


### PR DESCRIPTION
replaced `FTI_GetStageDir(const char* stageDir, int maxLen);` by `FTI_GetStageDir(char* stageDir, int maxLen);`. There is no need to make it a `const char*` It is an out variable.