### PR TITLE
Fix memory leak in FTI_Protect

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -969,7 +969,8 @@ int FTI_Protect(int id, void* ptr, int64_t count, fti_id_t tid) {
     }
     // Id could not be found in datasets
 
-    data = calloc(1, sizeof(FTIT_dataset));
+    FTIT_dataset dataNew = {0};
+    data = &dataNew;
 
     // Adding new variable to protect
     data->id = id;


### PR DESCRIPTION
When we add new FTIT_dataset instances to the keymap, we allocate memory, however, copy the new data structure into the keymap. We never free it's allocated memory.

This PR replaces the dynamic memory allocation by a stack allocation that is freed once out of scope.